### PR TITLE
feat!: switch accuracy command to be two-way not three-way

### DIFF
--- a/chart_review/agree.py
+++ b/chart_review/agree.py
@@ -24,17 +24,18 @@ def confusion_matrix(simple: dict, gold_ann: str, review_ann: str, note_range: I
     _ground_truth = simplify.rollup_mentions(simple, gold_ann, note_range)
     _reliability = simplify.rollup_mentions(simple, review_ann, note_range)
 
-    label_set = set()   # Must be labeled by ground truth at least 1x
+    # Only examine labels that were used by the ground truth or annotators least 1x
+    label_set = set()
     for _v in _ground_truth.values():
-        for label in _v:
-            label_set.add(label)
+        label_set |= set(_v)
+    for _v in _reliability.values():
+        label_set |= set(_v)
 
     TP = list()  # True Positive
     FP = list()  # False Positive
     FN = list()  # False Negative
     TN = list()  # True Negative
 
-    #for note_id in [str(n) for n in note_range]:
     for note_id in note_range:
         for label in label_set:
             if not label_pick or (label == label_pick):  # Pick label (default=None)

--- a/chart_review/cli.py
+++ b/chart_review/cli.py
@@ -40,15 +40,14 @@ def define_parser() -> argparse.ArgumentParser:
 def add_accuracy_subparser(subparsers) -> None:
     parser = subparsers.add_parser("accuracy")
     add_project_args(parser)
-    parser.add_argument("one")
-    parser.add_argument("two")
-    parser.add_argument("base")
+    parser.add_argument("ground_truth")
+    parser.add_argument("annotator")
     parser.set_defaults(func=run_accuracy)
 
 
 def run_accuracy(args: argparse.Namespace) -> None:
     reader = cohort.CohortReader(args.project_dir)
-    accuracy(reader, args.one, args.two, args.base)
+    accuracy(reader, args.ground_truth, args.annotator)
 
 
 ###############################################################################

--- a/chart_review/commands/accuracy.py
+++ b/chart_review/commands/accuracy.py
@@ -5,36 +5,29 @@ import os
 from chart_review import agree, cohort, common
 
 
-def accuracy(reader: cohort.CohortReader, first_ann: str, second_ann: str, base_ann: str) -> None:
+def accuracy(reader: cohort.CohortReader, truth: str, annotator: str) -> None:
     """
-    High-level accuracy calculation between three reviewers.
+    High-level accuracy calculation between an annotator and ground truth.
 
     The results will be written to the project directory.
 
     :param reader: the cohort configuration
-    :param first_ann: the first annotator to compare
-    :param second_ann: the second annotator to compare
-    :param base_ann: the base annotator to compare the others against
+    :param truth: ground truth reviewer
+    :param annotator: the annotator to compare against truth
     """
-    # Grab ranges
-    first_range = reader.config.note_ranges[first_ann]
-    second_range = reader.config.note_ranges[second_ann]
+    # Grab the intersection of ranges
+    note_range = set(reader.config.note_ranges[truth])
+    note_range &= set(reader.config.note_ranges[annotator])
 
     # All labels first
-    first_matrix = reader.confusion_matrix(first_ann, base_ann, first_range)
-    second_matrix = reader.confusion_matrix(second_ann, base_ann, second_range)
-    whole_matrix = agree.append_matrix(first_matrix, second_matrix)
-    table = agree.score_matrix(whole_matrix)
+    table = agree.score_matrix(reader.confusion_matrix(truth, annotator, note_range))
 
     # Now do each labels separately
     for label in reader.class_labels:
-        first_matrix = reader.confusion_matrix(first_ann, base_ann, first_range, label)
-        second_matrix = reader.confusion_matrix(second_ann, base_ann, second_range, label)
-        whole_matrix = agree.append_matrix(first_matrix, second_matrix)
-        table[label] = agree.score_matrix(whole_matrix)
+        table[label] = agree.score_matrix(reader.confusion_matrix(truth, annotator, note_range, label))
 
     # And write out the results
-    output_stem = os.path.join(reader.project_dir, f"accuracy-{first_ann}-{second_ann}-{base_ann}")
+    output_stem = os.path.join(reader.project_dir, f"accuracy-{truth}-{annotator}")
     common.write_json(f"{output_stem}.json", table)
     print(f"Wrote {output_stem}.json")
     common.write_text(f"{output_stem}.csv", agree.csv_table(table, reader.class_labels))

--- a/chart_review/simplify.py
+++ b/chart_review/simplify.py
@@ -17,6 +17,8 @@ def merge_simple(source: dict, append: dict) -> dict:
         merged['files'][file_id] = int(note_id)
         merged['annotations'][int(note_id)] = source['annotations'][int(note_id)]
 
+        if file_id not in append['files']:
+            continue
         append_id = append['files'][file_id]
         for annotator in append['annotations'][append_id]:
             for entry in append['annotations'][append_id][annotator]:
@@ -49,10 +51,8 @@ def simplify_full(exported_json: str, annotator_enum: config.AnnotatorMap) -> di
         for annot in entry.get('annotations'):
             completed_by = annot.get('completed_by')
             annotator = annotator_enum[completed_by]
-            label = None
+            label = []
             for result in annot.get('result'):
-                if not label:
-                    label = list()
                 match = result.get('value')
                 label.append(match)
 
@@ -114,10 +114,9 @@ def rollup_mentions(simple: dict, annotator: str, note_range: Iterable) -> dict:
                     if not rollup.get(note_id):
                         rollup[note_id] = list()
 
-                    symptom = annot['labels'][0]
-
-                    if symptom not in rollup[note_id]:
-                        rollup[note_id].append(symptom)
+                    for symptom in annot['labels']:
+                        if symptom not in rollup[note_id]:
+                            rollup[note_id].append(symptom)
     return rollup
 
 def deprecate_filter_note_range(simple: dict, note_range: Iterable) -> dict:

--- a/tests/data/cold/labelstudio-export.json
+++ b/tests/data/cold/labelstudio-export.json
@@ -19,6 +19,7 @@
               "text": "sigh",
               "labels": [
                 "Fatigue",
+                "Fatigue",
                 "Headache"
               ]
             }

--- a/tests/data/external/labelstudio-export.json
+++ b/tests/data/external/labelstudio-export.json
@@ -30,5 +30,20 @@
         "ABC": "Anon-ABC"
       }
     }
+  },
+  {
+    "id": 2,
+    "annotations": [
+      {
+        "id": 101,
+        "completed_by": 1,
+        "result": []
+      }
+    ],
+    "data": {
+      "docref_mappings": {
+        "Not-In-External": "Not-In-External"
+      }
+    }
   }
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,64 +20,64 @@ class TestCommandLine(unittest.TestCase):
     def test_accuracy(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             shutil.copytree(f"{DATA_DIR}/cold", tmpdir, dirs_exist_ok=True)
-            cli.main_cli(["accuracy", "--project-dir", tmpdir, "jane", "john", "jill"])
+            cli.main_cli(["accuracy", "--project-dir", tmpdir, "jill", "jane"])
 
-            accuracy_json = common.read_json(f"{tmpdir}/accuracy-jane-john-jill.json")
+            accuracy_json = common.read_json(f"{tmpdir}/accuracy-jill-jane.json")
             self.assertEqual(
                 {
+                    "F1": 0.667,
+                    "Sens": 0.75,
+                    "Spec": 0.6,
+                    "PPV": 0.6,
+                    "NPV": 0.75,
+                    "TP": 3,
+                    "FN": 1,
+                    "TN": 3,
+                    "FP": 2,
                     "Cough": {
                         "F1": 0.667,
-                        "FN": 0,
-                        "FP": 2,
-                        "NPV": 1.0,
-                        "PPV": 0.5,
-                        "Sens": 1.0,
-                        "Spec": 0.5,
-                        "TN": 2,
-                        "TP": 2,
-                    },
-                    "F1": 0.667,
-                    "FN": 3,
-                    "FP": 3,
-                    "Fatigue": {
-                        "F1": 0.889,
-                        "FN": 0,
-                        "FP": 1,
-                        "NPV": 1.0,
-                        "PPV": 0.8,
-                        "Sens": 1.0,
-                        "Spec": 0.5,
+                        "FN": 1,
+                        "FP": 0,
+                        "NPV": 0.5,
+                        "PPV": 1.0,
+                        "Sens": 0.5,
+                        "Spec": 1.0,
                         "TN": 1,
-                        "TP": 4,
+                        "TP": 1,
+                    },
+                    "Fatigue": {
+                        "F1": 1.0,
+                        "FN": 0,
+                        "FP": 0,
+                        "NPV": 1.0,
+                        "PPV": 1.0,
+                        "Sens": 1.0,
+                        "Spec": 1.0,
+                        "TN": 1,
+                        "TP": 2,
                     },
                     "Headache": {
                         "F1": 0,
-                        "FN": 3,
-                        "FP": 0,
+                        "FN": 0,
+                        "FP": 2,
                         "NPV": 0,
                         "PPV": 0,
                         "Sens": 0,
                         "Spec": 0,
-                        "TN": 3,
+                        "TN": 1,
                         "TP": 0,
                     },
-                    "NPV": 0.667,
-                    "PPV": 0.667,
-                    "Sens": 0.667,
-                    "Spec": 0.667,
-                    "TN": 6,
-                    "TP": 6,
                 },
                 accuracy_json,
             )
 
-            accuracy_csv = common.read_text(f"{tmpdir}/accuracy-jane-john-jill.csv")
+            accuracy_csv = common.read_text(f"{tmpdir}/accuracy-jill-jane.csv")
             self.assertEqual(
                 """F1	Sens	Spec	PPV	NPV	TP	FN	TN	FP	Label
-0.667	0.667	0.667	0.667	0.667	6	3	6	3	*
-0.667	1.0	0.5	0.5	1.0	2	0	2	2	Cough
-0.889	1.0	0.5	0.8	1.0	4	0	1	1	Fatigue
-0	0	0	0	0	0	3	3	0	Headache
+0.667	0.75	0.6	0.6	0.75	3	1	3	2	*
+0.667	0.5	1.0	1.0	0.5	1	1	1	0	Cough
+1.0	1.0	1.0	1.0	1.0	2	0	1	0	Fatigue
+0	0	0	0	0	0	0	1	2	Headache
 """,
                 accuracy_csv,
             )

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -23,12 +23,17 @@ class TestExternal(unittest.TestCase):
             reader = cohort.CohortReader(tmpdir)
 
             self.assertEqual({
-                "files": {1: 1},
+                "files": {1: 1, 2: 2},
                 "annotations": {
                     1: {
                         "human": [{"labels": ["happy"], "text": "woo"}, {"labels": ["sad"], "text": "sigh"}],
                         # icd10 labels are split into two lists, because we used two different docrefs (anon & real)
                         "icd10": [{"labels": ["happy", "tired"]}, {"labels": ["hungry"]}],
                     },
+                    # This was a note that didn't appear in the icd10 external annotations (and also didn't have a
+                    # positive label by the human reviewer) - just here to test that it didn't screw anything up.
+                    2: {
+                        "human": [],
+                    }
                 }
             }, reader.annotations)


### PR DESCRIPTION
I originally wrote it that way to imitate some code from covid_symptom/paper.py that was doing three-way comparisons.

But we often have need of simple two-way comparisons. And even my three-way comparison may not have been the best way to compare (paper.py might have been doing something a little unique, where it was actually doing two different two-way comparisons and I misunderstood intent).

So I intend to bring back multi-way comparison at some point, but it will with more design input from a clinical person. But for now, two-way is actively useful, so let's start with that.

In addition, there were some other bug fixes:
- Start migrating to a unified vocabulary for "annotations that are being compared" vs the "ground truth to compare against":
  - "annotator" is an in-evaluation set of annotations
  - "truth" (or "ground truth") is the gold standard comparison
  - Other terms like "gold" or "reviewer" will be phased out to reduce confusion
- When calculating a confusion matrix, we used to throw away any labels that weren't in the truth matrix. But that ignored False Positives in the annotator matrix for labels that truth never used. So now we only throw away labels that weren't in either matrix.
- When calculating accuracy, we previously reversed truth and annotator. This PR fixes that (so specificity and sensitivity will be reversed from before this PR -- to their correct values).
- When calculating accuracy, only deal with simply the intersection of note ranges between annotator and truth. (before we always used the annotator's note range, which might have notes not in truth)
- When merging two sets of annotations (like from Label Studio and an external set of labels), don't error out if Label Studio has notes not in the external set and don't ignore annotations that have more than one label in them (which happens with our generated annotations for external label sets, whoops)
- Updated unit tests and manually confirmed TN/FP/etc stats are right.