### PR TITLE
feat: add new config key 'ignore' for notes to skip

### DIFF
--- a/chart_review/common.py
+++ b/chart_review/common.py
@@ -22,7 +22,7 @@ def read_json(path: str) -> dict:
     logging.debug("read_json() %s", path)
 
     with open(path, "r") as f:
-        return json.load(f)
+        return json.load(f, strict=False)
 
 
 def write_json(path: str, data: dict, indent: Optional[int] = 4) -> None:

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -70,3 +70,7 @@ class ProjectConfig:
     @property
     def class_labels(self) -> list[str]:
         return self._data.setdefault("labels", [])
+
+    @property
+    def ignore(self) -> set[str]:
+        return set(self._data.setdefault("ignore", []))

--- a/tests/data/cold/labelstudio-export.json
+++ b/tests/data/cold/labelstudio-export.json
@@ -10,6 +10,7 @@
             "value": {
               "text": "achoo",
               "labels": [
+                "Label Not In Study",
                 "Cough"
               ]
             }

--- a/tests/data/external/doc.csv
+++ b/tests/data/external/doc.csv
@@ -1,7 +1,8 @@
-blarg_id,symptom
+doc_id,symptom
 "ABC","happy"
-"ABC","tired"
 "ABC-Enc","ignored"
-"Anon-ABC","hungry"
+"ABC","tired"
+"DocumentReference/Anon-ABC","sad"
+"Encounter/Anon-ABC-Enc","hungry"
 "Unmatched","lost"
 "No-Symptoms",

--- a/tests/data/external/enc.csv
+++ b/tests/data/external/enc.csv
@@ -1,7 +1,8 @@
-ENC_ID,SYMPTOM
+BLARG_ID,SYMPTOM
 "ABC-Enc","happy"
 "ABC","ignored"
 "ABC-Enc","tired"
-"Anon-ABC-Enc","hungry"
+"Encounter/Anon-ABC-Enc","sad"
+"DocumentReference/Anon-ABC","hungry"
 "Unmatched","lost"
 "No-Symptoms-Enc",

--- a/tests/data/ignore/config.yaml
+++ b/tests/data/ignore/config.yaml
@@ -1,0 +1,8 @@
+annotators:
+  adam: 1
+  allison: 2
+
+ignore:
+  - 3-Enc
+  - Encounter/Anon-4-Enc
+  - 5

--- a/tests/data/ignore/labelstudio-export.json
+++ b/tests/data/ignore/labelstudio-export.json
@@ -1,0 +1,153 @@
+[
+  {
+    "id": 1,
+    "annotations": [
+      {
+        "id": 101,
+        "completed_by": 1,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "A"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": 102,
+        "completed_by": 2,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "A"
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "data": {
+      "enc_id": "1-Enc",
+      "anon_id": "Anon-1-Enc"
+    }
+  },
+  {
+    "id": 2,
+    "annotations": [
+      {
+        "id": 101,
+        "completed_by": 1,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "B"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": 102,
+        "completed_by": 2,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "B"
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "data": {
+      "enc_id": "2-Enc",
+      "anon_id": "Anon-2-Enc"
+    }
+  },
+  {
+    "id": 3,
+    "annotations": [
+      {
+        "id": 101,
+        "completed_by": 1,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "A"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": 102,
+        "completed_by": 2,
+        "result": []
+      }
+    ],
+    "data": {
+      "enc_id": "3-Enc",
+      "anon_id": "Anon-3-Enc"
+    }
+  },
+  {
+    "id": 4,
+    "annotations": [
+      {
+        "id": 101,
+        "completed_by": 1,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "A"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": 102,
+        "completed_by": 2,
+        "result": []
+      }
+    ],
+    "data": {
+      "enc_id": "4-Enc",
+      "anon_id": "Anon-4-Enc"
+    }
+  },
+  {
+    "id": 5,
+    "annotations": [
+      {
+        "id": 101,
+        "completed_by": 1,
+        "result": [
+          {
+            "value": {
+              "labels": [
+                "A"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "id": 102,
+        "completed_by": 2,
+        "result": []
+      }
+    ],
+    "data": {
+      "enc_id": "5-Enc",
+      "anon_id": "Anon-5-Enc"
+    }
+  }
+]

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -39,7 +39,7 @@ class TestAgreement(unittest.TestCase):
         (
             "alice",
             "bob",
-            "Cough",
+            ["Cough"],
             {
                 "FN": [{1: "Cough"}],
                 "FP": [{2: "Cough"}],
@@ -49,7 +49,7 @@ class TestAgreement(unittest.TestCase):
         ),
     )
     @ddt.unpack
-    def test_confusion_matrix_counts(self, truth, annotator, label_pick, expected_matrix):
+    def test_confusion_matrix_counts(self, truth, annotator, labels, expected_matrix):
         """Verify that we can make a simple confusion matrix."""
         simple = {
             "annotations": {
@@ -65,5 +65,5 @@ class TestAgreement(unittest.TestCase):
         }
         notes = [1, 2]
 
-        matrix = agree.confusion_matrix(simple, truth, annotator, notes, label_pick=label_pick)
+        matrix = agree.confusion_matrix(simple, truth, annotator, notes, labels=labels)
         self.assertEqual(expected_matrix, matrix)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,3 +81,16 @@ class TestCommandLine(unittest.TestCase):
 """,
                 accuracy_csv,
             )
+
+    def test_ignored_ids(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shutil.copytree(f"{DATA_DIR}/ignore", tmpdir, dirs_exist_ok=True)
+            cli.main_cli(["accuracy", "--project-dir", tmpdir, "allison", "adam"])
+
+            # Only two of the five notes should be considered, and we should have full agreement.
+            accuracy_json = common.read_json(f"{tmpdir}/accuracy-allison-adam.json")
+            self.assertEqual(1, accuracy_json["F1"])
+            self.assertEqual(2, accuracy_json["TP"])
+            self.assertEqual(0, accuracy_json["FN"])
+            self.assertEqual(2, accuracy_json["TN"])
+            self.assertEqual(0, accuracy_json["FP"])

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -33,8 +33,16 @@ class TestExternal(unittest.TestCase):
                             ],
                             # icd10 labels are split into two lists,
                             # because we used two different docrefs (anon & real)
-                            "icd10-doc": [{"labels": ["happy", "tired"]}, {"labels": ["hungry"]}],
-                            "icd10-enc": [{"labels": ["happy", "tired"]}, {"labels": ["hungry"]}],
+                            "icd10-doc": [
+                                {"labels": ["happy", "tired"]},
+                                {"labels": ["sad"]},
+                                {"labels": ["hungry"]},
+                            ],
+                            "icd10-enc": [
+                                {"labels": ["happy", "tired"]},
+                                {"labels": ["sad"]},
+                                {"labels": ["hungry"]},
+                            ],
                         },
                         # This was a note that didn't appear in the icd10 external annotations
                         # (and also didn't have a positive label by the human reviewer).


### PR DESCRIPTION
You can now add config like the following to have matching notes excluded from any accuracy comparisons:

```
ignore:
  - 1023  # Label Studio note ID
  - ENC5342  # real ID
  - c3959eda-a67d-11ee-bd6e-b7eafa174aa3  # anonymized ID
  - Encounter/c3959eda-a67d-11ee-bd6e-b7eafa174aa3  # anonymized ref
```

Also some small tweaks:

- Always restrict the scored labels to the set of config-defined labels (if it exists). This prevents us from dinging an accuracy comparison on labels that aren't for the study.
- Parse label studio export json without strict mode - the export may reasonably include some control characters like newlines that make the json parser complain.
- Allow full references in external IDs (like Encounter/xxx) instead of requiring just the ID portion.
- Default to Encounter IDs if we can't figure out the ID type from the external csv headers.