### PR TITLE
feat: add new implied-labels config field

### DIFF
--- a/chart_review/cohort.py
+++ b/chart_review/cohort.py
@@ -113,7 +113,14 @@ class CohortReader:
         """
         labels = self._select_labels(label_pick)
         note_range = set(guard_iter(note_range)) - self.ignored_notes
-        return agree.confusion_matrix(self.annotations, truth, annotator, note_range, labels=labels)
+        return agree.confusion_matrix(
+            self.annotations,
+            truth,
+            annotator,
+            note_range,
+            labels=labels,
+            implied_labels=self.config.implied_labels,
+        )
 
     def score_reviewer(self, truth: str, annotator: str, note_range, label_pick: str = None):
         """

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -6,7 +6,7 @@ from typing import Iterable, Union
 
 import yaml
 
-AnnotatorMap = dict[int, str]
+from chart_review import types
 
 
 class ProjectConfig:
@@ -35,7 +35,7 @@ class ProjectConfig:
         # since that's what is stored in Label Studio. So that's what we return from this method.
         # But as humans writing config files, it's more natural to think of "name -> id".
         # So that's what we keep in the config, and we just reverse it here for convenience.
-        self.annotators: dict[int, str] = {}
+        self.annotators = types.AnnotatorMap()
         self.external_annotations = {}
         for name, value in self._data.get("annotators", {}).items():
             if isinstance(value, int):  # real annotation layer in Label Studio
@@ -48,6 +48,14 @@ class ProjectConfig:
         self.note_ranges = self._data.get("ranges", {})
         for key, values in self.note_ranges.items():
             self.note_ranges[key] = list(self._parse_note_range(values))
+
+        # ** Implied labels **
+        self.implied_labels = types.ImpliedLabels()
+        for key, value in self._data.get("implied-labels", {}).items():
+            # Coerce single labels into a set
+            if not isinstance(value, list):
+                value = {value}
+            self.implied_labels[key] = set(value)
 
     def _parse_note_range(self, value: Union[str, int, list[Union[str, int]]]) -> Iterable[int]:
         if isinstance(value, list):

--- a/chart_review/types.py
+++ b/chart_review/types.py
@@ -1,0 +1,10 @@
+"""Various type declarations for better type hinting."""
+
+# Map of label_studio_user_id: human name
+AnnotatorMap = dict[int, str]
+
+# Map of label_studio_note_id: {all labels for that note}
+Mentions = dict[int, set[str]]
+
+# Map of label: {all implied labels}
+ImpliedLabels = dict[str, set[str]]

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -67,3 +67,62 @@ class TestAgreement(unittest.TestCase):
 
         matrix = agree.confusion_matrix(simple, truth, annotator, notes, labels=labels)
         self.assertEqual(expected_matrix, matrix)
+
+    @ddt.data(
+        # Truth labels, Annotator labels, all expected assignments
+        (
+            ["Animal"],
+            ["Cat"],
+            {"TP": [{1: "Animal"}], "FP": [{1: "Cat"}, {1: "Pet"}]},
+        ),  # generic truth
+        (
+            ["Cat"],
+            ["Animal"],
+            {"TP": [{1: "Animal"}], "FN": [{1: "Cat"}, {1: "Pet"}]},
+        ),  # specific truth
+        (["Cat"], ["Cat"], {"TP": [{1: "Animal"}, {1: "Cat"}, {1: "Pet"}]}),  # specific agreement
+        (["Animal"], ["Animal"], {"TP": [{1: "Animal"}]}),  # generic agreement
+        # two layers deep, generic truth
+        (
+            ["Animal"],
+            ["Lion"],
+            {"TP": [{1: "Animal"}], "FP": [{1: "Cat"}, {1: "Lion"}, {1: "Pet"}]},
+        ),
+        # two layers deep, specific truth
+        (
+            ["Lion"],
+            ["Animal"],
+            {"TP": [{1: "Animal"}], "FN": [{1: "Cat"}, {1: "Lion"}, {1: "Pet"}]},
+        ),
+        # two layers deep, with mention of intermediate
+        (
+            ["Lion"],
+            ["Animal", "Cat"],
+            {"TP": [{1: "Animal"}, {1: "Cat"}, {1: "Pet"}], "FN": [{1: "Lion"}]},
+        ),
+    )
+    @ddt.unpack
+    def test_implied_labels(self, truth_labels, annotator_labels, expected_matrix):
+        """Verify that we handle labels that imply other labels."""
+        simple = {
+            "annotations": {
+                1: {
+                    "truth": [{"labels": truth_labels}],
+                    "annotator": [{"labels": annotator_labels}],
+                },
+            },
+        }
+        matrix = agree.confusion_matrix(
+            simple,
+            "truth",
+            "annotator",
+            [1],
+            labels={"Animal", "Cat", "Lion", "Pet"},
+            implied_labels={
+                "Cat": {"Animal", "Pet"},
+                "Lion": {"Cat"},
+            },
+        )
+        full_expected_matrix = {"TP": [], "FP": [], "TN": [], "FN": []}
+        full_expected_matrix.update(expected_matrix)
+        self.assertEqual(full_expected_matrix, matrix)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,3 +81,21 @@ class TestProjectConfig(unittest.TestCase):
             },
             proj_config.note_ranges,
         )
+
+    def test_implied_labels(self):
+        """Verify that we grab the label config correctly."""
+        proj_config = self.make_config(
+            """
+            implied-labels:
+                A: B
+                C: [D, E]
+            """
+        )
+
+        self.assertEqual(
+            {
+                "A": {"B"},
+                "C": {"D", "E"},
+            },
+            proj_config.implied_labels,
+        )


### PR DESCRIPTION
This commit adds a new configuration option that looks like:
```
implied-labels:
  Cat: Animal
  Lion: Cat
```

With the above config, when Truth has labeled Animal, and the annotator has labeled Lion, you'll see the following agreement matrix result:

Animal: TP
Lion: FP

This feature is useful for situations where one label implies another and/or has more priority over another.