### PR TITLE
feat: support secondary config files with --config

### DIFF
--- a/chart_review/cli.py
+++ b/chart_review/cli.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 
-from chart_review import cohort
+from chart_review import cohort, config
 from chart_review.commands.accuracy import accuracy
 
 
@@ -18,8 +18,14 @@ def add_project_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--project-dir",
         default=".",
-        help="Directory holding project files, "
-        "like config.yaml and labelstudio-export.json (default: current dir)",
+        metavar="DIR",
+        help=(
+            "Directory holding project files, "
+            "like labelstudio-export.json (default: current dir)"
+        ),
+    )
+    parser.add_argument(
+        "--config", "-c", metavar="PATH", help="Config file (default: [project-dir]/config.yaml)"
     )
 
 
@@ -49,7 +55,8 @@ def add_accuracy_subparser(subparsers) -> None:
 
 
 def run_accuracy(args: argparse.Namespace) -> None:
-    reader = cohort.CohortReader(args.project_dir)
+    proj_config = config.ProjectConfig(args.project_dir, config_path=args.config)
+    reader = cohort.CohortReader(proj_config)
     accuracy(reader, args.truth_annotator, args.annotator)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,3 +94,18 @@ class TestCommandLine(unittest.TestCase):
             self.assertEqual(0, accuracy_json["FN"])
             self.assertEqual(2, accuracy_json["TN"])
             self.assertEqual(0, accuracy_json["FP"])
+
+    def test_custom_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shutil.copy(f"{DATA_DIR}/cold/labelstudio-export.json", tmpdir)
+            cli.main_cli(
+                [
+                    "accuracy",
+                    "--project-dir",
+                    tmpdir,
+                    "-c",
+                    f"{DATA_DIR}/cold/config.yaml",
+                    "jane",
+                    "john",
+                ]
+            )  # just confirm it doesn't error out

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 import unittest
 
-from chart_review import cohort
+from chart_review import cohort, config
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -20,7 +20,7 @@ class TestExternal(unittest.TestCase):
     def test_basic_read(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             shutil.copytree(f"{DATA_DIR}/external", tmpdir, dirs_exist_ok=True)
-            reader = cohort.CohortReader(tmpdir)
+            reader = cohort.CohortReader(config.ProjectConfig(tmpdir))
 
             self.assertEqual(
                 {


### PR DESCRIPTION
This allows alternate study "modes" like different label setups.

Just point -c or --config at the path of your custom config.

Should solve #14