### PR TITLE
feat: add new config option 'grouped-labels' to combine labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## Vocabulary
+
+### Labels
+- **Label**: a tag that can be applied to a word, like "Fever" or "Ideation".
+  These are often applied by humans during a chart review in Label Studio,
+  but external sources like ICD10 codes can also be converted to labels.
+  We try to use "label" for the _idea_ of a label (class not instance).
+- **Mention**: a specific instance of a label applied to a note.
+- **Annotations**: the complete calculated set of mentions across all sources in the project.
+
+### Sources of Labels
+- **Annotator**: A generic chart reviewer / labeler.
+- **Truth**: The ground truth annotator during an accuracy comparison.
+- **External**: An annotator that does not come from Label Studio.
+  Usually this means a non-human source like ICD10 codes or NLP.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class **Cohort** defines the base class to analyze study cohorts.
 `simplify.py`
 * **rollup**(...) : return _LabelStudioExport_ with 1 "rollup" annotation replacing individual mentions
 
-`mentions.py` (methods are rarely used currently)
+`term_freq.py` (methods are rarely used currently)
 * overlaps(...) : test if two mentions overlap (True/False)
 * calc_term_freq(...) : term frequency of highlighted mention text
 * calc_term_label_confusion : report of exact mentions with 2+ class_labels

--- a/chart_review/cohort.py
+++ b/chart_review/cohort.py
@@ -1,47 +1,36 @@
-import os
 from typing import Iterable, Optional
 
 from chart_review.common import guard_str, guard_iter, guard_in
+from chart_review import agree
 from chart_review import common
 from chart_review import config
 from chart_review import external
+from chart_review import term_freq
 from chart_review import simplify
-from chart_review import mentions
-from chart_review import agree
+from chart_review import types
 
 
 class CohortReader:
+    """
+    CohortReader converts a Label Studio export and a project config into a standard form.
+
+    It also exposes some statistical helper methods.
+    """
+
     def __init__(self, proj_config: config.ProjectConfig):
         """
         :param proj_config: parsed project configuration
         """
         self.config = proj_config
         self.project_dir = self.config.project_dir
-        self.labelstudio_json = self.config.path("labelstudio-export.json")
-        self.annotator = self.config.annotators
-        self.note_range = self.config.note_ranges
-        self.class_labels = self.config.class_labels
-        self.annotations = simplify.simplify_full(self.labelstudio_json, self.annotator)
 
-        saved = common.read_json(self.labelstudio_json)
+        # Load exported annotations
+        saved = common.read_json(self.config.path("labelstudio-export.json"))
+        self.annotations = simplify.simplify_export(saved, self.config)
 
         # Load external annotations (i.e. from NLP tags or ICD10 codes)
         for name, value in self.config.external_annotations.items():
-            self.annotations = external.merge_external(
-                self.annotations, saved, self.project_dir, name, value
-            )
-
-        # Detect note ranges if they were not defined in the project config
-        # (i.e. default to the full set of annotated notes)
-        all_names = list(self.annotator.values())
-        all_names += list(self.config.external_annotations.keys())
-        for annotator in all_names:
-            if annotator not in self.note_range:
-                notes = []
-                for note_id, annotations in self.annotations["annotations"].items():
-                    if annotator in annotations:
-                        notes.append(note_id)
-                self.note_range[annotator] = notes
+            external.merge_external(self.annotations, saved, self.project_dir, name, value)
 
         # Parse ignored IDs (might be note IDs, might be external IDs)
         self.ignored_notes: set[int] = set()
@@ -55,13 +44,31 @@ class CohortReader:
                     continue
             self.ignored_notes.add(ls_id)
 
+        # Consolidate/expand mentions based on config
+        simplify.simplify_mentions(
+            self.annotations,
+            implied_labels=self.config.implied_labels,
+            grouped_labels=self.config.grouped_labels,
+        )
+
+        # Detect note ranges if they were not defined in the project config
+        # (i.e. default to the full set of annotated notes)
+        self.note_range = self.config.note_ranges
+        for annotator, annotator_mentions in self.annotations.mentions.items():
+            if annotator not in self.note_range:
+                self.note_range[annotator] = sorted(annotator_mentions.keys())
+
+    @property
+    def class_labels(self):
+        return self.annotations.labels
+
     def calc_term_freq(self, annotator) -> dict:
         """
         Calculate Term Frequency of highlighted mentions.
         :param annotator: an annotator name
         :return: dict key=TERM val= {label, list of chart_id}
         """
-        return mentions.calc_term_freq(self.annotations, guard_str(annotator))
+        return term_freq.calc_term_freq(self.annotations, guard_str(annotator))
 
     def calc_label_freq(self, annotator) -> dict:
         """
@@ -69,10 +76,10 @@ class CohortReader:
         :param annotator: an annotator name
         :return: dict key=TERM val= {label, list of chart_id}
         """
-        return mentions.calc_label_freq(self.calc_term_freq(annotator))
+        return term_freq.calc_label_freq(self.calc_term_freq(annotator))
 
     def calc_term_label_confusion(self, annotator) -> dict:
-        return mentions.calc_term_label_confusion(self.calc_term_freq(annotator))
+        return term_freq.calc_term_label_confusion(self.calc_term_freq(annotator))
 
     def _select_labels(self, label_pick: str = None) -> Optional[Iterable[str]]:
         if label_pick:
@@ -103,7 +110,6 @@ class CohortReader:
             annotator,
             note_range,
             labels=labels,
-            implied_labels=self.config.implied_labels,
         )
 
     def score_reviewer(self, truth: str, annotator: str, note_range, label_pick: str = None):

--- a/chart_review/commands/accuracy.py
+++ b/chart_review/commands/accuracy.py
@@ -23,7 +23,7 @@ def accuracy(reader: cohort.CohortReader, truth: str, annotator: str) -> None:
     table = agree.score_matrix(reader.confusion_matrix(truth, annotator, note_range))
 
     # Now do each labels separately
-    for label in reader.class_labels:
+    for label in sorted(reader.class_labels):
         table[label] = agree.score_matrix(
             reader.confusion_matrix(truth, annotator, note_range, label)
         )

--- a/chart_review/common.py
+++ b/chart_review/common.py
@@ -10,7 +10,7 @@ import json
 ###############################################################################
 
 
-def read_json(path: str) -> dict:
+def read_json(path: str) -> dict | list[dict]:
     """
     Reads json from a file
     :param path: filesystem path

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -47,6 +47,14 @@ class ProjectConfig:
                 value = {value}
             self.implied_labels[key] = set(value)
 
+        # ** Grouped labels **
+        self.grouped_labels = types.GroupedLabels()
+        for key, value in self._data.get("grouped-labels", {}).items():
+            # Coerce single labels into a set
+            if not isinstance(value, list):
+                value = {value}
+            self.grouped_labels[key] = set(value)
+
     def path(self, filename: str) -> str:
         return os.path.join(self.project_dir, filename)
 
@@ -86,8 +94,8 @@ class ProjectConfig:
             return []
 
     @property
-    def class_labels(self) -> list[str]:
-        return self._data.setdefault("labels", [])
+    def class_labels(self) -> types.LabelSet:
+        return set(self._data.setdefault("labels", []))
 
     @property
     def ignore(self) -> set[str]:

--- a/chart_review/term_freq.py
+++ b/chart_review/term_freq.py
@@ -1,29 +1,30 @@
 from ctakesclient.typesystem import Span
 
+from chart_review import types
 
-def calc_term_freq(simple: dict, annotator: str) -> dict:
+
+def calc_term_freq(annotations: types.ProjectAnnotations, annotator: str) -> dict:
     """
     Calculate the frequency of TERMS highlighted for each LABEL (Cough, Dyspnea, etc).
-    :param simple: prepared map of files and annotations
+    :param annotations: prepared map of mentions
     :param annotator: an annotator name
     :return: dict key=TERM val= {label, list of chart_id}
     """
-    term_freq = dict()
-    for note_id, values in simple["annotations"].items():
-        if values.get(annotator):
-            for annot in values.get(annotator):
-                term = annot["text"].upper()
-                label = annot["labels"][0]
-                if len(annot["labels"]) > 1:
-                    raise Exception(f"note_id = {note_id} \t {values}")
+    original_text_mentions = annotations.original_text_mentions.get(annotator, {})
 
-                if term not in term_freq.keys():
-                    term_freq[term] = dict()
+    term_freq = {}
+    for note_id, text_labels in original_text_mentions.items():
+        for text_label in text_labels:
+            if not text_label.text:
+                continue
 
-                if label not in term_freq[term].keys():
-                    term_freq[term][label] = list()
+            term = text_label.text.upper()
+            term_counts = term_freq.setdefault(term, {})
 
-                term_freq[term][label].append(note_id)
+            for label in text_label.labels:
+                term_label_counts = term_counts.setdefault(label, [])
+                term_label_counts.append(note_id)
+
     return term_freq
 
 

--- a/chart_review/types.py
+++ b/chart_review/types.py
@@ -1,10 +1,40 @@
 """Various type declarations for better type hinting."""
 
+import dataclasses
+from typing import Optional
+
 # Map of label_studio_user_id: human name
 AnnotatorMap = dict[int, str]
 
+LabelSet = set[str]
+
 # Map of label_studio_note_id: {all labels for that note}
-Mentions = dict[int, set[str]]
+# Usually used in the context of a specific annotator's label mentions.
+Mentions = dict[int, LabelSet]
 
 # Map of label: {all implied labels}
-ImpliedLabels = dict[str, set[str]]
+ImpliedLabels = dict[str, LabelSet]
+
+# Map of group: {all member labels}
+GroupedLabels = dict[str, LabelSet]
+
+
+@dataclasses.dataclass
+class LabeledText:
+    text: Optional[str]
+    labels: LabelSet
+
+
+@dataclasses.dataclass
+class ProjectAnnotations:
+    labels: LabelSet = dataclasses.field(default_factory=set)
+
+    # annotator_name -> Mentions
+    mentions: dict[str, Mentions] = dataclasses.field(default_factory=dict)
+
+    # We usually deal with simplified note-wide labels, but sometimes it's helpful to have
+    # the original text-to-label associations available, for term frequency analysis.
+    # annotators -> note_id -> list of text/label combos
+    original_text_mentions: dict[str, dict[int, list[LabeledText]]] = dataclasses.field(
+        default_factory=dict
+    )

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -4,7 +4,7 @@ import unittest
 
 import ddt
 
-from chart_review import agree
+from chart_review import agree, types
 
 
 @ddt.ddt
@@ -49,78 +49,14 @@ class TestAgreement(unittest.TestCase):
     @ddt.unpack
     def test_confusion_matrix_counts(self, truth, annotator, labels, expected_matrix):
         """Verify that we can make a simple confusion matrix."""
-        simple = {
-            "annotations": {
-                1: {
-                    "alice": [{"labels": ["Cough"]}],
-                    "bob": [{"labels": ["Headache"]}],
-                },
-                2: {
-                    "alice": [{"labels": ["Fever"]}],
-                    "bob": [{"labels": ["Fever", "Cough"]}],
-                },
-            },
-        }
-        notes = [1, 2]
-
-        matrix = agree.confusion_matrix(simple, truth, annotator, notes, labels=labels)
-        self.assertEqual(expected_matrix, matrix)
-
-    @ddt.data(
-        # Truth labels, Annotator labels, all expected assignments
-        (
-            ["Animal"],
-            ["Cat"],
-            {"TP": [{1: "Animal"}], "FP": [{1: "Cat"}, {1: "Pet"}]},
-        ),  # generic truth
-        (
-            ["Cat"],
-            ["Animal"],
-            {"TP": [{1: "Animal"}], "FN": [{1: "Cat"}, {1: "Pet"}]},
-        ),  # specific truth
-        (["Cat"], ["Cat"], {"TP": [{1: "Animal"}, {1: "Cat"}, {1: "Pet"}]}),  # specific agreement
-        (["Animal"], ["Animal"], {"TP": [{1: "Animal"}]}),  # generic agreement
-        # two layers deep, generic truth
-        (
-            ["Animal"],
-            ["Lion"],
-            {"TP": [{1: "Animal"}], "FP": [{1: "Cat"}, {1: "Lion"}, {1: "Pet"}]},
-        ),
-        # two layers deep, specific truth
-        (
-            ["Lion"],
-            ["Animal"],
-            {"TP": [{1: "Animal"}], "FN": [{1: "Cat"}, {1: "Lion"}, {1: "Pet"}]},
-        ),
-        # two layers deep, with mention of intermediate
-        (
-            ["Lion"],
-            ["Animal", "Cat"],
-            {"TP": [{1: "Animal"}, {1: "Cat"}, {1: "Pet"}], "FN": [{1: "Lion"}]},
-        ),
-    )
-    @ddt.unpack
-    def test_implied_labels(self, truth_labels, annotator_labels, expected_matrix):
-        """Verify that we handle labels that imply other labels."""
-        simple = {
-            "annotations": {
-                1: {
-                    "truth": [{"labels": truth_labels}],
-                    "annotator": [{"labels": annotator_labels}],
-                },
-            },
-        }
-        matrix = agree.confusion_matrix(
-            simple,
-            "truth",
-            "annotator",
-            [1],
-            labels={"Animal", "Cat", "Lion", "Pet"},
-            implied_labels={
-                "Cat": {"Animal", "Pet"},
-                "Lion": {"Cat"},
+        annotations = types.ProjectAnnotations(
+            labels={"Cough", "Fever", "Headache"},
+            mentions={
+                "alice": {1: {"Cough"}, 2: {"Fever"}},
+                "bob": {1: {"Headache"}, 2: {"Cough", "Fever"}},
             },
         )
-        full_expected_matrix = {"TP": [], "FP": [], "TN": [], "FN": []}
-        full_expected_matrix.update(expected_matrix)
-        self.assertEqual(full_expected_matrix, matrix)
+        notes = [1, 2]
+
+        matrix = agree.confusion_matrix(annotations, truth, annotator, notes, labels=labels)
+        self.assertEqual(expected_matrix, matrix)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,7 @@ class TestProjectConfig(unittest.TestCase):
         """Verify that we can operate on multiple formats (like json & yaml)."""
         proj_config = self.make_config(text, filename=f"config.{suffix}")
 
-        self.assertEqual(["cough", "fever"], proj_config.class_labels)
+        self.assertEqual({"cough", "fever"}, proj_config.class_labels)
         self.assertEqual({1: "jane", 2: "john"}, proj_config.annotators)
         self.assertEqual({"jane": [3], "john": [1, 3, 5]}, proj_config.note_ranges)
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -24,42 +24,20 @@ class TestExternal(unittest.TestCase):
 
             self.assertEqual(
                 {
-                    "files": {1: 1, 2: 2, 3: 3},
-                    "annotations": {
-                        1: {
-                            "human": [
-                                {"labels": ["happy"], "text": "woo"},
-                                {"labels": ["sad"], "text": "sigh"},
-                            ],
-                            # icd10 labels are split into two lists,
-                            # because we used two different docrefs (anon & real)
-                            "icd10-doc": [
-                                {"labels": ["happy", "tired"]},
-                                {"labels": ["sad"]},
-                                {"labels": ["hungry"]},
-                            ],
-                            "icd10-enc": [
-                                {"labels": ["happy", "tired"]},
-                                {"labels": ["sad"]},
-                                {"labels": ["hungry"]},
-                            ],
-                        },
+                    "human": {
+                        1: {"happy", "sad"},
                         # This was a note that didn't appear in the icd10 external annotations
                         # (and also didn't have a positive label by the human reviewer).
                         # Just here to test that it didn't screw anything up.
-                        2: {
-                            "human": [],
-                        },
+                        2: set(),
                         # This was an external annotation that said "saw it,
                         # but no labels for this note"
-                        3: {
-                            "human": [],
-                            "icd10-doc": [],
-                            "icd10-enc": [],
-                        },
+                        3: set(),
                     },
+                    "icd10-doc": {1: {"happy", "hungry", "sad", "tired"}, 3: set()},
+                    "icd10-enc": {1: {"happy", "hungry", "sad", "tired"}, 3: set()},
                 },
-                reader.annotations,
+                reader.annotations.mentions,
             )
 
             # Confirm ranges got auto-detected for both human and icd10

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,0 +1,67 @@
+"""Tests for simplify.py"""
+
+import unittest
+
+import ddt
+
+from chart_review import simplify, types
+
+
+@ddt.ddt
+class TestSimplify(unittest.TestCase):
+    """Test case for annotation simplification"""
+
+    @ddt.data(
+        ({"Cat"}, {"Animal", "Cat", "Pet"}),  # Basic expansion
+        ({"Animal", "Dangerous", "Venomous"}, {"Animal", "Risky"}),  # Basic grouping
+        ({"Lion"}, {"Animal", "Cat", "Lion", "Pet", "Risky"}),  # Two layers deep, plus grouping
+    )
+    @ddt.unpack
+    def test_simplify_mentions(self, input_labels, expected_labels):
+        """Verify that we handle implied and grouped labels."""
+        annotations = types.ProjectAnnotations(
+            # Note that the group names are not part of this label set yet.
+            # This set generally starts with just the human-tagged input labels.
+            labels={"Animal", "Cat", "Dangerous", "Lion", "Pet", "Venomous"},
+            mentions={
+                "katherine": {1: input_labels},
+            },
+        )
+        simplify.simplify_mentions(
+            annotations,
+            implied_labels={
+                "Cat": {"Animal", "Pet"},
+                "Lion": {"Cat", "Dangerous"},
+            },
+            grouped_labels={
+                # Dangerous overlaps with implied labels above, to test ordering
+                "Risky": {"Dangerous", "Venomous"},
+            },
+        )
+        self.assertEqual(expected_labels, annotations.mentions["katherine"][1])
+        self.assertEqual({"Animal", "Cat", "Lion", "Pet", "Risky"}, annotations.labels)
+
+    def test_binary_grouping(self):
+        """Verify that grouping all labels down to a simple yes/no works as expected."""
+        annotations = types.ProjectAnnotations(
+            labels={"Blue", "Green", "Red"},
+            mentions={
+                "paint-bot": {
+                    1: {"Blue"},
+                    2: set(),
+                    3: {"Red", "Green"},
+                },
+            },
+        )
+        simplify.simplify_mentions(
+            annotations,
+            implied_labels={},
+            grouped_labels={
+                "Painted": {"Blue", "Green", "Red"},
+            },
+        )
+        self.assertEqual(
+            {1: {"Painted"}, 2: set(), 3: {"Painted"}},
+            annotations.mentions["paint-bot"],
+        )
+        self.assertEqual({"Painted"}, annotations.labels)

--- a/tests/test_term_freq.py
+++ b/tests/test_term_freq.py
@@ -1,0 +1,29 @@
+"""Tests for term_freq.py"""
+
+import unittest
+
+from chart_review import term_freq, types
+
+
+class TestMentions(unittest.TestCase):
+    """Test case for term frequency calculations"""
+
+    def test_calc_term_freq(self):
+        annotations = types.ProjectAnnotations(
+            original_text_mentions={
+                "hank": {
+                    1: [
+                        types.LabeledText("achoo", {"Cough", "Onomatopoeia"}),
+                        types.LabeledText(None, {"Fever"}),
+                        types.LabeledText("cough", {"Cough"}),
+                    ]
+                },
+            },
+        )
+        self.assertEqual(
+            {
+                "ACHOO": {"Cough": [1], "Onomatopoeia": [1]},
+                "COUGH": {"Cough": [1]},
+            },
+            term_freq.calc_term_freq(annotations, "hank"),
+        )


### PR DESCRIPTION
This is basically the reverse of implied-labels. Instead of expanding labels, we restrict the whole set down to a smaller one.

Example:
```
labels: [Fever, Cough, Pain]
grouped-labels:
  Sick: [Fever, Cough, Pain]
```

Would result in not 3 separate labels being scored, but just one.

**I also took this opportunity to refactor things a bit.**

I basically expanded the idea of "simplifying the export data" into a real class model and moved some code from agree.py to simplify.py.