### PR TITLE
feat: add `info` subcommand to show computed ranges & labels

### DIFF
--- a/chart_review/__init__.py
+++ b/chart_review/__init__.py
@@ -1,3 +1,3 @@
 """Chart Review public entry point"""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/chart_review/cli.py
+++ b/chart_review/cli.py
@@ -5,6 +5,7 @@ import sys
 
 from chart_review import cohort, config
 from chart_review.commands.accuracy import accuracy
+from chart_review.commands.info import info
 
 
 ###############################################################################
@@ -35,6 +36,7 @@ def define_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(required=True)
 
     add_accuracy_subparser(subparsers)
+    add_info_subparser(subparsers)
 
     return parser
 
@@ -59,6 +61,25 @@ def run_accuracy(args: argparse.Namespace) -> None:
     proj_config = config.ProjectConfig(args.project_dir, config_path=args.config)
     reader = cohort.CohortReader(proj_config)
     accuracy(reader, args.truth_annotator, args.annotator, save=args.save)
+
+
+###############################################################################
+#
+# Info
+#
+###############################################################################
+
+
+def add_info_subparser(subparsers) -> None:
+    parser = subparsers.add_parser("info")
+    add_project_args(parser)
+    parser.set_defaults(func=run_info)
+
+
+def run_info(args: argparse.Namespace) -> None:
+    proj_config = config.ProjectConfig(args.project_dir, config_path=args.config)
+    reader = cohort.CohortReader(proj_config)
+    info(reader)
 
 
 ###############################################################################

--- a/chart_review/commands/info.py
+++ b/chart_review/commands/info.py
@@ -1,0 +1,64 @@
+"""Methods for showing config & calculated setup info."""
+
+import rich
+import rich.box
+import rich.table
+
+from chart_review import cohort
+
+
+def info(reader: cohort.CohortReader) -> None:
+    """
+    Show project information on the console.
+
+    :param reader: the cohort configuration
+    """
+    console = rich.get_console()
+
+    # Charts
+    chart_table = rich.table.Table(
+        "Annotator",
+        "Chart Count",
+        "Chart IDs",
+        box=rich.box.ROUNDED,
+        pad_edge=False,
+        title="Annotations:",
+        title_justify="left",
+        title_style="bold",
+    )
+    for annotator in sorted(reader.note_range):
+        notes = reader.note_range[annotator]
+        chart_table.add_row(annotator, str(len(notes)), pretty_note_range(notes))
+    console.print(chart_table)
+    console.print()
+
+    # Labels
+    console.print("Labels:", style="bold")
+    if reader.class_labels:
+        console.print(", ".join(sorted(reader.class_labels, key=str.casefold)))
+    else:
+        console.print("None", style="italic", highlight=False)
+
+
+def pretty_note_range(notes: set[int]) -> str:
+    ranges = []
+    range_start = None
+    prev_note = None
+
+    def end_range() -> None:
+        if prev_note is None:
+            return
+        if range_start == prev_note:
+            ranges.append(str(prev_note))
+        else:
+            ranges.append(f"{range_start}–{prev_note}")  # en dash
+
+    for note in sorted(notes):
+        if prev_note is None or prev_note + 1 != note:
+            end_range()
+            range_start = note
+        prev_note = note
+
+    end_range()
+
+    return ", ".join(ranges)

--- a/chart_review/common.py
+++ b/chart_review/common.py
@@ -23,7 +23,7 @@ def read_json(path: str) -> Union[dict, list[dict]]:
         return json.load(f, strict=False)
 
 
-def write_json(path: str, data: dict, indent: Optional[int] = 4) -> None:
+def write_json(path: str, data: dict | list, indent: Optional[int] = 4) -> None:
     """
     Writes data to the given path, in json format
     :param path: filesystem path

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -35,7 +35,7 @@ class ProjectConfig:
 
         # ** Note ranges **
         # Handle some extra syntax like 1-3 == [1, 2, 3]
-        self.note_ranges = self._data.get("ranges", {})
+        self.note_ranges: dict[str, list[int]] = self._data.get("ranges", {})
         for key, values in self.note_ranges.items():
             self.note_ranges[key] = list(self._parse_note_range(values))
 

--- a/chart_review/simplify.py
+++ b/chart_review/simplify.py
@@ -22,7 +22,7 @@ def simplify_export(
     for entry in exported_json:
         note_id = int(entry.get("id"))
 
-        for annot in entry.get("annotations"):
+        for annot in entry.get("annotations", []):
             completed_by = annot.get("completed_by")
             if completed_by not in proj_config.annotators:
                 continue  # we don't know who this is!
@@ -30,7 +30,7 @@ def simplify_export(
             # Grab all valid mentions for this annotator & note
             labels = types.LabelSet()
             text_tags = []
-            for result in annot.get("result"):
+            for result in annot.get("result", []):
                 result_value = result.get("value", {})
                 result_text = result_value.get("text")
                 result_labels = set(result_value.get("labels", []))

--- a/docs/info.md
+++ b/docs/info.md
@@ -1,0 +1,42 @@
+---
+title: Info Command
+parent: Chart Review
+nav_order: 6
+# audience: lightly technical folks
+# type: how-to
+---
+
+# The Info Command
+
+The `info` command will print information about your current project.
+
+This is helpful to examine the computed list of chart ID ranges or labels.
+
+## Example
+
+```shell
+$ chart-review info
+Annotations:                              
+╭──────────┬─────────────┬──────────╮
+│Annotator │ Chart Count │ Chart IDs│
+├──────────┼─────────────┼──────────┤
+│jane      │ 3           │ 1, 3–4   │
+│jill      │ 4           │ 1–4      │
+│john      │ 3           │ 1–2, 4   │
+╰──────────┴─────────────┴──────────╯
+
+Labels:
+Cough, Fatigue, Headache
+```
+
+## Options
+
+### `--config=PATH`
+
+Use this to point to a secondary (non-default) config file.
+Useful if you have multiple label setups (e.g. one grouped into a binary label and one not).
+
+### `--project-dir=DIR`
+
+Use this to run `chart-review` outside of your project dir.
+Config files, external annotations, etc will be looked for in that directory. 

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -1,0 +1,45 @@
+"""Tests for cohort.py"""
+
+import os
+import tempfile
+import unittest
+
+from chart_review import cohort, common, config
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+class TestCohort(unittest.TestCase):
+    """Test case for basic cohort management"""
+
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
+
+    def test_ignored_ids(self):
+        reader = cohort.CohortReader(config.ProjectConfig(f"{DATA_DIR}/ignore"))
+
+        # Confirm 3, 4, and 5 got ignored
+        self.assertEqual(
+            {
+                "adam": {1, 2},
+                "allison": {1, 2},
+            },
+            reader.note_range,
+        )
+
+    def test_non_existent_ids(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            common.write_json(
+                f"{tmpdir}/config.json", {"annotators": {"bob": 1}, "ranges": {"bob": ["1-5"]}}
+            )
+            common.write_json(
+                f"{tmpdir}/labelstudio-export.json",
+                [
+                    {"id": 1, "annotations": [{"completed_by": 1}]},  # done by bob
+                    {"id": 3},  # not done by bob, but we are explicitly told it was
+                ],
+            )
+            reader = cohort.CohortReader(config.ProjectConfig(tmpdir))
+
+            self.assertEqual({"bob": {1, 3}}, reader.note_range)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -43,9 +43,9 @@ class TestExternal(unittest.TestCase):
             # Confirm ranges got auto-detected for both human and icd10
             self.assertEqual(
                 {
-                    "human": [1, 2, 3],
-                    "icd10-doc": [1, 3],
-                    "icd10-enc": [1, 3],
+                    "human": {1, 2, 3},
+                    "icd10-doc": {1, 3},
+                    "icd10-enc": {1, 3},
                 },
                 reader.note_range,
             )


### PR DESCRIPTION
`chart-review info` will now print some useful project stats to the console. Namely, a list of annotators and their note count & ranges, as well as a list of the final computed labels.

We can augment this over time or add flags to it. But this felt like a reasonable start.

![image](https://github.com/smart-on-fhir/chart-review/assets/1196901/f272afd2-443d-4fec-90ae-9c2b0828488d)

Fixes: #33

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
