### PR TITLE
feat(info): add --labels flag to print label statistics

### DIFF
--- a/chart_review/console_utils.py
+++ b/chart_review/console_utils.py
@@ -1,7 +1,9 @@
 """Helper methods for printing to the console."""
 
+from chart_review import types
 
-def pretty_note_range(notes: set[int]) -> str:
+
+def pretty_note_range(notes: types.NoteSet) -> str:
     """
     Returns a pretty, human-readable string for a set of notes.
 

--- a/chart_review/types.py
+++ b/chart_review/types.py
@@ -7,6 +7,7 @@ from typing import Optional
 AnnotatorMap = dict[int, str]
 
 LabelSet = set[str]
+NoteSet = set[int]
 
 # Map of label_studio_note_id: {all labels for that note}
 # Usually used in the context of a specific annotator's label mentions.

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,7 +100,7 @@ The new group labels do not need to be a part of your source `labels` list.
 #### Example
 ```yaml
 grouped-labels:
-  ill: [insomnia, chickenpox, ebola]
+  animal: [dog, cat, fox]
 ```
 
 ### `ignore`

--- a/docs/info.md
+++ b/docs/info.md
@@ -16,7 +16,6 @@ This is helpful to examine the computed list of chart ID ranges or labels.
 
 ```shell
 $ chart-review info
-Annotations:                              
 ╭──────────┬─────────────┬──────────╮
 │Annotator │ Chart Count │ Chart IDs│
 ├──────────┼─────────────┼──────────┤
@@ -24,9 +23,6 @@ Annotations:
 │jill      │ 4           │ 1–4      │
 │john      │ 3           │ 1–2, 4   │
 ╰──────────┴─────────────┴──────────╯
-
-Labels:
-Cough, Fatigue, Headache
 ```
 
 ## Options
@@ -57,6 +53,35 @@ chart_id,original_fhir_id,anonymized_fhir_id
 2,Encounter/E898,Encounter/8b0bd207147989492801b7c14eebc015564ab73a07bdabdf9aefc3425eeba982
 2,DocumentReference/D898,DocumentReference/b5e329b752067eca1584f9cd132f40c637d8a9ebd6f2a599794f9436fb83c2eb
 2,DocumentReference/D899,DocumentReference/605338cd18c2617864db23fd5fd956f3e806af2021ffa6d11c34cac998eb3b6d
+```
+
+### `--labels`
+
+Prints some statistics on the project labels and how often each annotator used each label.
+
+#### Example
+
+```shell
+$ chart-review info --labels
+╭───────────┬─────────────┬──────────╮
+│ Annotator │ Chart Count │ Label    │
+├───────────┼─────────────┼──────────┤
+│ Any       │ 2           │ Cough    │
+│ Any       │ 3           │ Fatigue  │
+│ Any       │ 3           │ Headache │
+├───────────┼─────────────┼──────────┤
+│ jane      │ 1           │ Cough    │
+│ jane      │ 2           │ Fatigue  │
+│ jane      │ 2           │ Headache │
+├───────────┼─────────────┼──────────┤
+│ jill      │ 2           │ Cough    │
+│ jill      │ 3           │ Fatigue  │
+│ jill      │ 0           │ Headache │
+├───────────┼─────────────┼──────────┤
+│ john      │ 1           │ Cough    │
+│ john      │ 2           │ Fatigue  │
+│ john      │ 2           │ Headache │
+╰───────────┴─────────────┴──────────╯
 ```
 
 ### `--config=PATH`


### PR DESCRIPTION
With `chart-review info --labels`, you'll get a table summarizing how often each label was used by each annotator, plus a unioned view of how often each label was used by _any_ annotator.

I Also took out the little list of labels printed with just bare `info` since it felt redundant and let me simplify that view a bit. Not committed to this stance, but it felt cleaner to me.

I've reviewed with Andy about some of the more "what would a researcher want to see?" choices here - like the "union" Any-annotator section and using the final grouped labels instead of the intermediate labels.

![image](https://github.com/smart-on-fhir/chart-review/assets/1196901/fb61a97d-9919-49ee-8519-2c4284490eb7)


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
