### PR TITLE
feat(accuracy): add --verbose to print table of per-chart results

### DIFF
--- a/chart_review/__init__.py
+++ b/chart_review/__init__.py
@@ -1,3 +1,3 @@
 """Chart Review public entry point"""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/chart_review/agree.py
+++ b/chart_review/agree.py
@@ -183,12 +183,12 @@ def score_reviewer(
     return score_matrix(truth_matrix)
 
 
-def csv_table(score: dict, class_labels: Iterable):
+def csv_table(score: dict, class_labels: types.LabelSet):
     table = list()
     table.append(csv_header(False, True))
     table.append(csv_row_score(score, as_string=True))
 
-    for label in sorted(class_labels):
+    for label in sorted(class_labels, key=str.casefold):
         table.append(csv_row_score(score[label], label, as_string=True))
     return "\n".join(table) + "\n"
 

--- a/chart_review/commands/accuracy.py
+++ b/chart_review/commands/accuracy.py
@@ -4,12 +4,20 @@ import argparse
 import os
 
 import rich
+import rich.box
 import rich.table
+import rich.text
 
 from chart_review import agree, cli_utils, cohort, common, config, console_utils
 
 
-def accuracy(reader: cohort.CohortReader, truth: str, annotator: str, save: bool = False) -> None:
+def accuracy(
+    reader: cohort.CohortReader,
+    truth: str,
+    annotator: str,
+    save: bool = False,
+    verbose: bool = False,
+) -> None:
     """
     High-level accuracy calculation between two annotators.
 
@@ -19,6 +27,7 @@ def accuracy(reader: cohort.CohortReader, truth: str, annotator: str, save: bool
     :param truth: the truth annotator
     :param annotator: the other annotator to compare against truth
     :param save: whether to write the results to disk vs just printing them
+    :param verbose: whether to print per-chart/per-label classifications
     """
     if truth not in reader.note_range:
         print(f"Unrecognized annotator '{truth}'")
@@ -31,44 +40,66 @@ def accuracy(reader: cohort.CohortReader, truth: str, annotator: str, save: bool
     note_range = set(reader.note_range[truth])
     note_range &= set(reader.note_range[annotator])
 
-    # All labels first
-    table = agree.score_matrix(reader.confusion_matrix(truth, annotator, note_range))
+    labels = sorted(reader.class_labels, key=str.casefold)
 
-    # Now do each labels separately
-    for label in sorted(reader.class_labels):
-        table[label] = agree.score_matrix(
-            reader.confusion_matrix(truth, annotator, note_range, label)
-        )
+    # Calculate confusion matrices
+    matrices = {None: reader.confusion_matrix(truth, annotator, note_range)}
+    for label in labels:
+        matrices[label] = reader.confusion_matrix(truth, annotator, note_range, label)
+
+    # Now score them
+    scores = agree.score_matrix(matrices[None])
+    for label in labels:
+        scores[label] = agree.score_matrix(matrices[label])
+
+    console = rich.get_console()
 
     note_count = len(note_range)
     chart_word = "chart" if note_count == 1 else "charts"
     pretty_ranges = f" ({console_utils.pretty_note_range(note_range)})" if note_count > 0 else ""
-    print(f"Comparing {note_count} {chart_word}{pretty_ranges}")
-    print(f"Truth: {truth}")
-    print(f"Annotator: {annotator}")
-    print()
+    console.print(f"Comparing {note_count} {chart_word}{pretty_ranges}")
+    console.print(f"Truth: {truth}")
+    console.print(f"Annotator: {annotator}")
 
+    console.print()
     if save:
         # Write the results out to disk
         output_stem = os.path.join(reader.project_dir, f"accuracy-{truth}-{annotator}")
-        common.write_json(f"{output_stem}.json", table)
-        print(f"Wrote {output_stem}.json")
-        common.write_text(f"{output_stem}.csv", agree.csv_table(table, reader.class_labels))
-        print(f"Wrote {output_stem}.csv")
+        common.write_json(f"{output_stem}.json", scores)
+        console.print(f"Wrote {output_stem}.json")
+        common.write_text(f"{output_stem}.csv", agree.csv_table(scores, reader.class_labels))
+        console.print(f"Wrote {output_stem}.csv")
     else:
         # Print the results out to the console
         rich_table = rich.table.Table(*agree.csv_header(), "Label", box=None, pad_edge=False)
-        rich_table.add_row(*agree.csv_row_score(table), "*")
-        for label in sorted(reader.class_labels):
-            rich_table.add_row(*agree.csv_row_score(table[label]), label)
-        rich.get_console().print(rich_table)
+        rich_table.add_row(*agree.csv_row_score(scores), "*")
+        for label in labels:
+            rich_table.add_row(*agree.csv_row_score(scores[label]), label)
+        console.print(rich_table)
+
+    if verbose:
+        # Print a table of each chart/label combo - useful for reviewing where an annotator
+        # went wrong.
+        verbose_table = rich.table.Table(
+            "Chart ID", "Label", "Classification", box=rich.box.ROUNDED
+        )
+        for note_id in sorted(note_range):
+            verbose_table.add_section()
+            for label in labels:
+                for classification in ["TN", "TP", "FN", "FP"]:
+                    if {note_id: label} in matrices[label][classification]:
+                        style = "bold" if classification[0] == "F" else None  # highlight errors
+                        class_text = rich.text.Text(classification, style=style)
+                        verbose_table.add_row(str(note_id), label, class_text)
+                        break
+        console.print()
+        console.print(verbose_table)
 
 
 def make_subparser(parser: argparse.ArgumentParser) -> None:
     cli_utils.add_project_args(parser)
-    parser.add_argument(
-        "--save", action="store_true", default=False, help="Write stats to CSV & JSON files"
-    )
+    parser.add_argument("--save", action="store_true", help="Write stats to CSV & JSON files")
+    parser.add_argument("--verbose", action="store_true", help="Explain each chart’s labels")
     parser.add_argument("truth_annotator")
     parser.add_argument("annotator")
     parser.set_defaults(func=run_accuracy)
@@ -77,4 +108,4 @@ def make_subparser(parser: argparse.ArgumentParser) -> None:
 def run_accuracy(args: argparse.Namespace) -> None:
     proj_config = config.ProjectConfig(args.project_dir, config_path=args.config)
     reader = cohort.CohortReader(proj_config)
-    accuracy(reader, args.truth_annotator, args.annotator, save=args.save)
+    accuracy(reader, args.truth_annotator, args.annotator, save=args.save, verbose=args.verbose)

--- a/docs/accuracy.md
+++ b/docs/accuracy.md
@@ -46,3 +46,39 @@ Config files, external annotations, etc will be looked for in that directory.
 Use this to write a JSON and CSV file to the project directory,
 rather than printing to the console.
 Useful for passing results around in a machine-parsable format.
+
+### `--verbose`
+
+Use this to also print out a table of per-chart/per-label classifications.
+This is helpful for investigating where specifically the two annotators agreed or not.
+
+#### Example
+
+```shell
+$ chart-review accuracy jill jane --verbose
+Comparing 3 charts (1, 3–4)
+Truth: jill
+Annotator: jane
+
+F1     Sens  Spec  PPV  NPV   Kappa  TP  FN  TN  FP  Label   
+0.667  0.75  0.6   0.6  0.75  0.341  3   1   3   2   *       
+0.667  0.5   1.0   1.0  0.5   0.4    1   1   1   0   Cough   
+1.0    1.0   1.0   1.0  1.0   1.0    2   0   1   0   Fatigue 
+0      0     0     0    0     0      0   0   1   2   Headache
+
+╭──────────┬──────────┬────────────────╮
+│ Chart ID │ Label    │ Classification │
+├──────────┼──────────┼────────────────┤
+│ 1        │ Cough    │ TP             │
+│ 1        │ Fatigue  │ TP             │
+│ 1        │ Headache │ FP             │
+├──────────┼──────────┼────────────────┤
+│ 3        │ Cough    │ TN             │
+│ 3        │ Fatigue  │ TN             │
+│ 3        │ Headache │ TN             │
+├──────────┼──────────┼────────────────┤
+│ 4        │ Cough    │ FN             │
+│ 4        │ Fatigue  │ TP             │
+│ 4        │ Headache │ FP             │
+╰──────────┴──────────┴────────────────╯
+```

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,25 @@
+"""Base class for tests"""
+
+import contextlib
+import io
+import os
+import unittest
+
+from chart_review import cli
+
+
+class TestCase(unittest.TestCase):
+    """Test case parent class"""
+
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
+
+    @staticmethod
+    def run_cli(*args) -> str:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            cli.main_cli(list(args))
+        return stdout.getvalue()

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -1,14 +1,13 @@
 """Tests for agree.py"""
 
-import unittest
-
 import ddt
 
 from chart_review import agree, types
+from tests import base
 
 
 @ddt.ddt
-class TestAgreement(unittest.TestCase):
+class TestAgreement(base.TestCase):
     """Test case for basic agreement logic"""
 
     @ddt.data(

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -1,20 +1,13 @@
 """Tests for cohort.py"""
 
-import os
 import tempfile
-import unittest
 
 from chart_review import cohort, common, config
+from tests import base
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-
-class TestCohort(unittest.TestCase):
+class TestCohort(base.TestCase):
     """Test case for basic cohort management"""
-
-    def setUp(self):
-        super().setUp()
-        self.maxDiff = None
 
     def test_no_specified_label(self):
         """Verify that no label setup grabs all found labels from the export."""
@@ -48,7 +41,7 @@ class TestCohort(unittest.TestCase):
         self.assertEqual({"Label A", "Label B"}, reader.class_labels)
 
     def test_ignored_ids(self):
-        reader = cohort.CohortReader(config.ProjectConfig(f"{DATA_DIR}/ignore"))
+        reader = cohort.CohortReader(config.ProjectConfig(f"{self.DATA_DIR}/ignore"))
 
         # Confirm 3, 4, and 5 got ignored
         self.assertEqual(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,20 +2,16 @@
 
 import os
 import tempfile
-import unittest
 
 import ddt
 
 from chart_review import common, config
+from tests import base
 
 
 @ddt.ddt
-class TestProjectConfig(unittest.TestCase):
+class TestProjectConfig(base.TestCase):
     """Test case for basic config parsing"""
-
-    def setUp(self):
-        super().setUp()
-        self.maxDiff = None
 
     def make_config(self, conf_text: str, filename: str = "config.yaml") -> config.ProjectConfig:
         tmpdir = tempfile.TemporaryDirectory()

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,51 +1,39 @@
 """Tests for external.py"""
 
-import os
-import shutil
-import tempfile
-import unittest
-
 from chart_review import cohort, config
+from tests import base
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
-
-class TestExternal(unittest.TestCase):
+class TestExternal(base.TestCase):
     """Test case for basic external ID merging"""
 
-    def setUp(self):
-        super().setUp()
-        self.maxDiff = None
-
     def test_basic_read(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            shutil.copytree(f"{DATA_DIR}/external", tmpdir, dirs_exist_ok=True)
-            reader = cohort.CohortReader(config.ProjectConfig(tmpdir))
+        reader = cohort.CohortReader(config.ProjectConfig(f"{self.DATA_DIR}/external"))
 
-            self.assertEqual(
-                {
-                    "human": {
-                        1: {"happy", "sad"},
-                        # This was a note that didn't appear in the icd10 external annotations
-                        # (and also didn't have a positive label by the human reviewer).
-                        # Just here to test that it didn't screw anything up.
-                        2: set(),
-                        # This was an external annotation that said "saw it,
-                        # but no labels for this note"
-                        3: set(),
-                    },
-                    "icd10-doc": {1: {"happy", "hungry", "sad", "tired"}, 3: set()},
-                    "icd10-enc": {1: {"happy", "hungry", "sad", "tired"}, 3: set()},
+        self.assertEqual(
+            {
+                "human": {
+                    1: {"happy", "sad"},
+                    # This was a note that didn't appear in the icd10 external annotations
+                    # (and also didn't have a positive label by the human reviewer).
+                    # Just here to test that it didn't screw anything up.
+                    2: set(),
+                    # This was an external annotation that said "saw it,
+                    # but no labels for this note"
+                    3: set(),
                 },
-                reader.annotations.mentions,
-            )
+                "icd10-doc": {1: {"happy", "hungry", "sad", "tired"}, 3: set()},
+                "icd10-enc": {1: {"happy", "hungry", "sad", "tired"}, 3: set()},
+            },
+            reader.annotations.mentions,
+        )
 
-            # Confirm ranges got auto-detected for both human and icd10
-            self.assertEqual(
-                {
-                    "human": {1, 2, 3},
-                    "icd10-doc": {1, 3},
-                    "icd10-enc": {1, 3},
-                },
-                reader.note_range,
-            )
+        # Confirm ranges got auto-detected for both human and icd10
+        self.assertEqual(
+            {
+                "human": {1, 2, 3},
+                "icd10-doc": {1, 3},
+                "icd10-enc": {1, 3},
+            },
+            reader.note_range,
+        )

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,32 +1,16 @@
 """Tests for commands/info.py"""
 
-import contextlib
-import io
-import os
 import tempfile
-import unittest
 
-from chart_review import cli, common
-
-DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+from chart_review import common
+from tests import base
 
 
-class TestInfo(unittest.TestCase):
+class TestInfo(base.TestCase):
     """Test case for the top-level info code"""
 
-    def setUp(self):
-        super().setUp()
-        self.maxDiff = None
-
-    @staticmethod
-    def grab_output(*args) -> str:
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            cli.main_cli(["info", *args])
-        return stdout.getvalue()
-
     def test_info(self):
-        stdout = self.grab_output("--project-dir", f"{DATA_DIR}/cold")
+        stdout = self.run_cli("info", "--project-dir", f"{self.DATA_DIR}/cold")
 
         self.assertEqual(
             """╭───────────┬─────────────┬───────────╮
@@ -41,7 +25,7 @@ class TestInfo(unittest.TestCase):
         )
 
     def test_info_ignored(self):
-        stdout = self.grab_output("--project-dir", f"{DATA_DIR}/ignore")
+        stdout = self.run_cli("info", "--project-dir", f"{self.DATA_DIR}/ignore")
 
         self.assertEqual(
             """╭───────────┬─────────────┬───────────╮
@@ -71,7 +55,7 @@ class TestInfo(unittest.TestCase):
                     },
                 ],
             )
-            stdout = self.grab_output("--ids", "--project-dir", tmpdir)
+            stdout = self.run_cli("info", "--ids", "--project-dir", tmpdir)
 
         lines = stdout.splitlines()
         self.assertEqual(2, len(lines))
@@ -144,7 +128,7 @@ class TestInfo(unittest.TestCase):
                     },
                 ],
             )
-            stdout = self.grab_output("--ids", "--project-dir", tmpdir)
+            stdout = self.run_cli("info", "--ids", "--project-dir", tmpdir)
 
         self.assertEqual(
             [
@@ -161,7 +145,7 @@ class TestInfo(unittest.TestCase):
         )
 
     def test_labels(self):
-        stdout = self.grab_output("--project-dir", f"{DATA_DIR}/cold", "--labels")
+        stdout = self.run_cli("info", "--project-dir", f"{self.DATA_DIR}/cold", "--labels")
 
         self.assertEqual(
             """╭───────────┬─────────────┬──────────╮
@@ -201,7 +185,7 @@ class TestInfo(unittest.TestCase):
                 f"{tmpdir}/labelstudio-export.json",
                 [],
             )
-            stdout = self.grab_output("--labels", "--project-dir", tmpdir)
+            stdout = self.run_cli("info", "--labels", "--project-dir", tmpdir)
 
         self.assertEqual(
             """╭───────────┬─────────────┬──────────╮
@@ -232,7 +216,7 @@ class TestInfo(unittest.TestCase):
                     {"id": 6},
                 ],
             )
-            stdout = self.grab_output("--labels", "--project-dir", tmpdir)
+            stdout = self.run_cli("info", "--labels", "--project-dir", tmpdir)
 
         self.assertEqual(
             "Ignoring 3 charts (3–4, 6)",

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,14 +1,13 @@
 """Tests for simplify.py"""
 
-import unittest
-
 import ddt
 
 from chart_review import simplify, types
+from tests import base
 
 
 @ddt.ddt
-class TestSimplify(unittest.TestCase):
+class TestSimplify(base.TestCase):
     """Test case for annotation simplification"""
 
     @ddt.data(

--- a/tests/test_term_freq.py
+++ b/tests/test_term_freq.py
@@ -1,11 +1,10 @@
 """Tests for term_freq.py"""
 
-import unittest
-
 from chart_review import term_freq, types
+from tests import base
 
 
-class TestMentions(unittest.TestCase):
+class TestMentions(base.TestCase):
     """Test case for term frequency calculations"""
 
     def test_calc_term_freq(self):


### PR DESCRIPTION
`accuracy --verbose` will now print a table of chart id / label / classification for the annotator, like this:
```
    ╭──────────┬──────────┬────────────────╮
    │ Chart ID │ Label    │ Classification │
    ├──────────┼──────────┼────────────────┤
    │ 1        │ Cough    │ TP             │
    │ 1        │ Fatigue  │ TP             │
    ├──────────┼──────────┼────────────────┤
    │ 4        │ Cough    │ FP             │
    │ 4        │ Fatigue  │ TP             │
    ╰──────────┴──────────┴────────────────╯
```

This is in addition to normal stat output. If `--save` is passed, the verbose bit is still only printed to the console.

Fixes: #40 

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
