### PR TITLE
fix: give better explanations for invalid project folders

### DIFF
--- a/chart_review/cohort.py
+++ b/chart_review/cohort.py
@@ -1,13 +1,7 @@
-from typing import Iterable, Optional
+from typing import Iterable
 
 from chart_review.common import guard_str, guard_iter, guard_in
-from chart_review import agree
-from chart_review import common
-from chart_review import config
-from chart_review import external
-from chart_review import term_freq
-from chart_review import simplify
-from chart_review import types
+from chart_review import agree, common, config, errors, external, term_freq, simplify, types
 
 
 class CohortReader:
@@ -25,7 +19,11 @@ class CohortReader:
         self.project_dir = self.config.project_dir
 
         # Load exported annotations
-        self.ls_export = common.read_json(self.config.path("labelstudio-export.json"))
+        try:
+            self.ls_export = common.read_json(self.config.path("labelstudio-export.json"))
+        except Exception as exc:
+            errors.exit_for_invalid_project(str(exc))
+
         self.annotations = simplify.simplify_export(self.ls_export, self.config)
 
         # Add a placeholder for any annotators that don't have mentions for some reason

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -7,7 +7,7 @@ from typing import Iterable, Optional, Union
 import rich.console
 import yaml
 
-from chart_review import types
+from chart_review import errors, types
 
 
 class ProjectConfig:
@@ -20,19 +20,9 @@ class ProjectConfig:
         """
         self.project_dir = project_dir or "."
         try:
-            self._data = self._load_config(config_path)
-        except FileNotFoundError as exc:
-            # Be very helpful - this is likely the user's first experience with this project.
-            stderr = rich.console.Console(stderr=True)
-            stderr.print(exc, style="bold red", highlight=False)
-            stderr.print()
-            stderr.print("This does not appear to be a chart-review project folder.")
-            stderr.print(
-                "See https://docs.smarthealthit.org/cumulus/chart-review/ to set up your project."
-            )
-            stderr.print()
-            stderr.print("Or pass --help for usage info.")
-            sys.exit(2)
+            self._data = self._load_config(config_path) or {}
+        except Exception as exc:
+            errors.exit_for_invalid_project(str(exc))
 
         # ** Annotators **
         # Internally, we're often dealing with numeric ID as the primary annotator identifier,

--- a/chart_review/errors.py
+++ b/chart_review/errors.py
@@ -1,0 +1,18 @@
+import sys
+from typing import NoReturn
+
+import rich.console
+
+ERROR_INVALID_PROJECT = 10
+
+
+def exit_for_invalid_project(msg: str) -> NoReturn:
+    # Be very helpful - this is likely the user's first interaction with chart-review.
+    stderr = rich.console.Console(stderr=True)
+    stderr.print(msg, style="bold red", highlight=False)
+    stderr.print()
+    stderr.print("This does not appear to be a chart-review project folder.")
+    stderr.print("See https://docs.smarthealthit.org/cumulus/chart-review/ to set up your project.")
+    stderr.print()
+    stderr.print("Or pass --help for usage info.")
+    sys.exit(ERROR_INVALID_PROJECT)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 
 import chart_review
-from chart_review import cli
+from chart_review import cli, common, errors
 from tests import base
 
 
@@ -66,3 +66,23 @@ Pass --help to see more options.
             # mostly confirm it doesn't just error out
             stdout = self.run_cli(f"--config={self.DATA_DIR}/cold/config.yaml", path=tmpdir)
             self.assert_cold_output(stdout)
+
+    def test_missing_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(SystemExit) as cm:
+                self.run_cli(path=tmpdir)
+        self.assertEqual(cm.exception.code, errors.ERROR_INVALID_PROJECT)
+
+    def test_empty_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            common.write_text(f"{tmpdir}/config.yaml", "")
+            with self.assertRaises(SystemExit) as cm:
+                self.run_cli(path=tmpdir)
+        self.assertEqual(cm.exception.code, errors.ERROR_INVALID_PROJECT)
+
+    def test_missing_export(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            common.write_json(f"{tmpdir}/config.yaml", {"annotators": {"me": 1}})
+            with self.assertRaises(SystemExit) as cm:
+                self.run_cli(path=tmpdir)
+        self.assertEqual(cm.exception.code, errors.ERROR_INVALID_PROJECT)


### PR DESCRIPTION
If the config or label studio export don't look write or don't exist, give the user a bit more of a pointer to what is wrong.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
