### PR TITLE
docs: prevent double-hyphens from being converted to a dash

### DIFF
--- a/docs/accuracy.md
+++ b/docs/accuracy.md
@@ -31,7 +31,7 @@ F1     Sens  Spec  PPV  NPV   Kappa  TP  FN  TN  FP  Label
 
 ## Options
 
-### --verbose
+### \-\-verbose
 
 Use this to also print out a table of per-chart/per-label classifications.
 This is helpful for investigating where specifically the two annotators agreed or not.
@@ -61,7 +61,7 @@ Annotator: jane
 ╰──────────┴──────────┴────────────────╯
 ```
 
-### --csv
+### \-\-csv
 
 Print the accuracy chart in a machine-parseable CSV format.
 

--- a/docs/frequency.md
+++ b/docs/frequency.md
@@ -55,7 +55,7 @@ $ chart-review frequency
 
 ## Options
 
-### --csv
+### \-\-csv
 
 Print the frequencies in a machine-parseable CSV format.
 

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -70,7 +70,7 @@ $ chart-review ids
 
 ## Options
 
-### --csv
+### \-\-csv
 
 Print the IDs in a machine-parseable CSV format.
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -38,7 +38,7 @@ $ chart-review labels
 
 ## Options
 
-### --csv
+### \-\-csv
 
 Print the labels in a machine-parseable CSV format.
 

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -40,7 +40,7 @@ $ chart-review mentions
 
 ## Options
 
-### --csv
+### \-\-csv
 
 Print the mentions in a machine-parseable CSV format.
 


### PR DESCRIPTION
This prevents just-the-docs from auto-converting the double-hyphen to a nice typographic dash, which normally I would love.

I don't like using code tickmarks in these header cases, since it makes them not look like a header - when I'm scrolling through a doc and I see code formatting, I'm expecting it to be in the body, and it doesn't look like a header to me.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
