### PR TITLE
fix: add better error message for a bad config

### DIFF
--- a/chart_review/__init__.py
+++ b/chart_review/__init__.py
@@ -1,3 +1,3 @@
 """Chart Review public entry point"""
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -71,13 +71,19 @@ class ProjectConfig:
         if config_path is None:
             # Support config.json in case folks prefer that
             try:
-                return self._read_yaml(self.path("config.json"))
+                config = self._read_yaml(self.path("config.json"))
             except FileNotFoundError:
-                return self._read_yaml(self.path("config.yaml"))
+                config = self._read_yaml(self.path("config.yaml"))
+        else:
+            # Don't resolve config_path relative to the project dir, because
+            # this will have come from the command line and will resolve relative to `pwd`.
+            config = self._read_yaml(config_path)
 
-        # Don't resolve config_path relative to the project dir, because
-        # this will have come from the command line and will resolve relative to `pwd`.
-        return self._read_yaml(config_path)
+        # Do some minimal validation on the config file
+        if not isinstance(config, dict):
+            raise ValueError("Config file is not in the expected dictionary format.")
+
+        return config
 
     def _parse_note_range(self, value: Union[str, int, list[Union[str, int]]]) -> Iterable[int]:
         if isinstance(value, list):

--- a/docs/config.md
+++ b/docs/config.md
@@ -166,6 +166,7 @@ But it may be useful to manually define the note range in unusual cases.
 - You can provide a list of Label Studio note IDs.
 - You can reference other defined ranges.
 - You can specify a range of IDs with a hyphen.
+- Ranges are inclusive. That is, `2-4` includes notes 2, 3, and 4.
 
 #### Example
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,9 +73,10 @@ Pass --help to see more options.
                 self.run_cli(path=tmpdir)
         self.assertEqual(cm.exception.code, errors.ERROR_INVALID_PROJECT)
 
-    def test_empty_config(self):
+    def test_bad_config(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            common.write_text(f"{tmpdir}/config.yaml", "")
+            shutil.copy(f"{self.DATA_DIR}/cold/labelstudio-export.json", tmpdir)
+            common.write_text(f"{tmpdir}/config.json", "[1, 2]")
             with self.assertRaises(SystemExit) as cm:
                 self.run_cli(path=tmpdir)
         self.assertEqual(cm.exception.code, errors.ERROR_INVALID_PROJECT)


### PR DESCRIPTION
If you accidentally pass in the labelstudio export file as the config file (or just otherwise have a malformed config), this will give a nicer error message.

Also, clarify in the docs that ranges are inclusive.

Fixes: #56
Fixes: #57

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
