### PR TITLE
Bugfix: Updates mcnemar command remove `--continuity-correction`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /site/
 __pycache__/
+/venv

--- a/chart_review/__init__.py
+++ b/chart_review/__init__.py
@@ -1,3 +1,3 @@
 """Chart Review public entry point"""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/chart_review/commands/mcnemar.py
+++ b/chart_review/commands/mcnemar.py
@@ -34,6 +34,7 @@ def print_mcnemar(args: argparse.Namespace) -> None:
     truth = args.truth_annotator
     annotator1 = args.annotator1
     annotator2 = args.annotator2
+    continuity_correction = args.continuity_correction
 
     all_people = {truth, annotator1, annotator2}
     annotators = [annotator1, annotator2]
@@ -66,7 +67,9 @@ def print_mcnemar(args: argparse.Namespace) -> None:
     empty_val = "" if args.csv else "N/A"
     for label in labels:
         m = matrices[label]
-        mcn, pval = _mcnemar(len(m["OL"]), len(m["OR"]), continuity_correction=True)
+        mcn, pval = _mcnemar(
+            len(m["OL"]), len(m["OR"]), continuity_correction=continuity_correction
+        )
         table.add_row(
             empty_val if mcn is None else _small_float(mcn),
             _small_float(pval),

--- a/chart_review/commands/mcnemar.py
+++ b/chart_review/commands/mcnemar.py
@@ -18,7 +18,6 @@ def make_subparser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("truth_annotator")
     parser.add_argument("annotator1")
     parser.add_argument("annotator2")
-    parser.add_argument("--continuity-correction", action="store_true")
     parser.set_defaults(func=print_mcnemar)
 
 
@@ -34,7 +33,6 @@ def print_mcnemar(args: argparse.Namespace) -> None:
     truth = args.truth_annotator
     annotator1 = args.annotator1
     annotator2 = args.annotator2
-    continuity_correction = args.continuity_correction
 
     all_people = {truth, annotator1, annotator2}
     annotators = [annotator1, annotator2]
@@ -67,9 +65,7 @@ def print_mcnemar(args: argparse.Namespace) -> None:
     empty_val = "" if args.csv else "N/A"
     for label in labels:
         m = matrices[label]
-        mcn, pval = _mcnemar(
-            len(m["OL"]), len(m["OR"]), continuity_correction=continuity_correction
-        )
+        mcn, pval = _mcnemar(len(m["OL"]), len(m["OR"]), continuity_correction=True)
         table.add_row(
             empty_val if mcn is None else _small_float(mcn),
             _small_float(pval),

--- a/tests/test_mcnemar.py
+++ b/tests/test_mcnemar.py
@@ -31,6 +31,7 @@ N/A      0.035     1   16  6   27  B
         stdout = self.run_cli(
             "mcnemar", "--csv", "alice", "bob", "carla", path=f"{self.DATA_DIR}/many-notes"
         )
+
         self.assertEqual(
             [
                 "mcnemar,p-value,bc,ol,or,bw,label",

--- a/tests/test_mcnemar.py
+++ b/tests/test_mcnemar.py
@@ -19,6 +19,33 @@ Truth: alice
 Annotators: bob, carla
 
 McNemar  P-value   BC  OL  OR  BW  Label
+13.136   2.90e-04  20  61  27  42  *    
+7.538    0.006     10  20  6   14  A    
+N/A      0.035     1   16  6   27  B    
+2.5      0.114     9   25  15  1   C    
+""",
+            stdout,
+        )
+
+    def test_continutity_correction(self):
+        stdout = self.run_cli(
+            "mcnemar",
+            "--continuity-correction",
+            "alice",
+            "bob",
+            "carla",
+            path=f"{self.DATA_DIR}/many-notes",
+        )
+
+        # This tests that the continuity correction effects the rows
+        # that use the chi-squared distribution to generate their mcnemar value
+        # i.e. the first, second, and fourth row - they all have (OR + OL) >= 25
+        self.assertEqual(
+            """Comparing 50 charts (1–50)
+Truth: alice
+Annotators: bob, carla
+
+McNemar  P-value   BC  OL  OR  BW  Label
 12.375   4.35e-04  20  61  27  42  *    
 6.5      0.011     10  20  6   14  A    
 N/A      0.035     1   16  6   27  B    
@@ -35,10 +62,10 @@ N/A      0.035     1   16  6   27  B
         self.assertEqual(
             [
                 "mcnemar,p-value,bc,ol,or,bw,label",
-                "12.375,4.35e-04,20,61,27,42,*",
-                "6.5,0.011,10,20,6,14,A",
+                "13.136,2.90e-04,20,61,27,42,*",
+                "7.538,0.006,10,20,6,14,A",
                 ",0.035,1,16,6,27,B",
-                "2.025,0.155,9,25,15,1,C",
+                "2.5,0.114,9,25,15,1,C",
             ],
             stdout.splitlines(),
         )

--- a/tests/test_mcnemar.py
+++ b/tests/test_mcnemar.py
@@ -19,33 +19,6 @@ Truth: alice
 Annotators: bob, carla
 
 McNemar  P-value   BC  OL  OR  BW  Label
-13.136   2.90e-04  20  61  27  42  *    
-7.538    0.006     10  20  6   14  A    
-N/A      0.035     1   16  6   27  B    
-2.5      0.114     9   25  15  1   C    
-""",
-            stdout,
-        )
-
-    def test_continutity_correction(self):
-        stdout = self.run_cli(
-            "mcnemar",
-            "--continuity-correction",
-            "alice",
-            "bob",
-            "carla",
-            path=f"{self.DATA_DIR}/many-notes",
-        )
-
-        # This tests that the continuity correction effects the rows
-        # that use the chi-squared distribution to generate their mcnemar value
-        # i.e. the first, second, and fourth row - they all have (OR + OL) >= 25
-        self.assertEqual(
-            """Comparing 50 charts (1–50)
-Truth: alice
-Annotators: bob, carla
-
-McNemar  P-value   BC  OL  OR  BW  Label
 12.375   4.35e-04  20  61  27  42  *    
 6.5      0.011     10  20  6   14  A    
 N/A      0.035     1   16  6   27  B    
@@ -58,14 +31,13 @@ N/A      0.035     1   16  6   27  B
         stdout = self.run_cli(
             "mcnemar", "--csv", "alice", "bob", "carla", path=f"{self.DATA_DIR}/many-notes"
         )
-
         self.assertEqual(
             [
                 "mcnemar,p-value,bc,ol,or,bw,label",
-                "13.136,2.90e-04,20,61,27,42,*",
-                "7.538,0.006,10,20,6,14,A",
+                "12.375,4.35e-04,20,61,27,42,*",
+                "6.5,0.011,10,20,6,14,A",
                 ",0.035,1,16,6,27,B",
-                "2.5,0.114,9,25,15,1,C",
+                "2.025,0.155,9,25,15,1,C",
             ],
             stdout.splitlines(),
         )


### PR DESCRIPTION
04/28 update: After discussing more with @mikix offline, we came to the conclusion that the original intention was to remove the `--continuity-correction` flag. The `print_mcnemar` commands use of `corr=True` is intentional and the expected bevahior. Updating this PR accordingly.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
