### PR TITLE
Allow no config at all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4  # keep in rough sync with pyproject.toml
+    rev: v0.12.3  # keep in rough sync with pyproject.toml
     hooks:
       - name: Ruff formatting
         id: ruff-format

--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -73,7 +73,10 @@ class ProjectConfig:
             try:
                 config = self._read_yaml(self.path("config.json"))
             except FileNotFoundError:
-                config = self._read_yaml(self.path("config.yaml"))
+                try:
+                    config = self._read_yaml(self.path("config.yaml"))
+                except FileNotFoundError:
+                    config = {}
         else:
             # Don't resolve config_path relative to the project dir, because
             # this will have come from the command line and will resolve relative to `pwd`.

--- a/chart_review/simplify.py
+++ b/chart_review/simplify.py
@@ -23,9 +23,13 @@ def simplify_export(
         note_id = int(entry.get("id"))
 
         for annot in entry.get("annotations", []):
+            # Determine annotator
             completed_by = annot.get("completed_by")
-            if completed_by not in proj_config.annotators:
-                continue  # we don't know who this is!
+            if completed_by is None:
+                continue  # we don't know who annotated this!
+            if proj_config.annotators and completed_by not in proj_config.annotators:
+                continue  # user specified an annotators config, and this one doesn't fit
+            annotator = proj_config.annotators.get(completed_by, str(completed_by))
 
             # Grab all valid mentions for this annotator & note
             labels = defines.LabelSet()
@@ -42,7 +46,6 @@ def simplify_export(
                 annotations.labels |= labels
 
             # Store these mentions in the main annotations list, by author & note
-            annotator = proj_config.annotators[completed_by]
             annotator_mentions = annotations.mentions.setdefault(annotator, defines.Mentions())
             annotator_mentions[note_id] = labels
             annot_orig_text_tags = annotations.original_text_mentions.setdefault(annotator, {})

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,16 +29,19 @@ secondary config will be used instead of the default config.
 
 ## Required Fields
 
-The only truly required field is `annotators`,
-which provides a mapping from names to Label Studio ID values.
+All fields have some reasonable default, and thus none are required.
+In fact, you can skip using a config file altogether, if the defaults work for you.
 
-Every other field has some reasonable default.
+But it's strongly recommended to make a config for at least the `annotators` field,
+because otherwise you'll be stuck talking about "annotator 1 and 2" instead of "Alice and Bob".
 
 ## Field Definitions
 
 ### `annotators`
 
-This is a required mapping of human-readable names to Label Studio IDs.
+This is a mapping of human-readable names to Label Studio IDs.
+
+Any Label Studio ID not mentioned in this mapping will be ignored.
 
 #### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ But calculating accuracy between human annotators can be done entirely without t
 ## Installing & Using
 
 ```shell
-pip install chart-review
+pipx install chart-review
 chart-review --help
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,7 +10,7 @@ nav_order: 1
 
 ## Installing
 
-`pip install chart-review`
+`pipx install chart-review`
 
 ## Make Project Directory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,8 @@ dependencies = [
 ]
 description = "Medical Record Chart Review Calculator"
 readme = "README.md"
-license = { text="Apache License 2.0" }
+license = "Apache-2.0"
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -27,7 +26,7 @@ Source = "https://github.com/smart-on-fhir/chart-review"
 chart-review = "chart_review.cli:main_cli"
 
 [build-system]
-requires = ["flit_core >=3.4,<4"]
+requires = ["flit_core >=3.12,<4"]
 build-backend = "flit_core.buildapi"
 
 [project.optional-dependencies]
@@ -40,7 +39,7 @@ dev = [
     "pre-commit",
     # Ruff is using minor versions for breaking changes until their 1.0 release.
     # See https://docs.astral.sh/ruff/versioning/
-    "ruff < 0.10",  # keep in rough sync with pre-commit-config.yaml
+    "ruff < 0.13",  # keep in rough sync with pre-commit-config.yaml
 ]
 
 [tool.flit.sdist]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,10 +68,24 @@ Pass --help to see more options.
             self.assert_cold_output(stdout)
 
     def test_missing_config(self):
+        """Still works, just with rough defaults"""
         with tempfile.TemporaryDirectory() as tmpdir:
-            with self.assertRaises(SystemExit) as cm:
-                self.run_cli(path=tmpdir)
-        self.assertEqual(cm.exception.code, errors.ERROR_INVALID_PROJECT)
+            shutil.copy(f"{self.DATA_DIR}/cold/labelstudio-export.json", tmpdir)
+            stdout = self.run_cli(path=tmpdir)
+
+            self.assertEqual(
+                """╭───────────┬─────────────┬───────────╮
+│ Annotator │ Chart Count │ Chart IDs │
+├───────────┼─────────────┼───────────┤
+│ 3         │ 4           │ 1–4       │
+│ 5         │ 3           │ 1–2, 4    │
+│ 6         │ 4           │ 1–4       │
+╰───────────┴─────────────┴───────────╯
+
+Pass --help to see more options.
+""",
+                stdout,
+            )
 
     def test_bad_config(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -80,6 +80,18 @@ class TestCohort(base.TestCase):
             reader = cohort.CohortReader(config.ProjectConfig(tmpdir))
             self.assertEqual({"bob": {1}}, reader.note_range)
 
+    def test_default_annotator_config(self):
+        """Should use a string version of the completed_by ID for the names"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            common.write_json(
+                f"{tmpdir}/labelstudio-export.json",
+                [
+                    {"id": 1, "annotations": [{"completed_by": 1}, {"completed_by": 2}]},
+                ],
+            )
+            reader = cohort.CohortReader(config.ProjectConfig(tmpdir))
+            self.assertEqual({"1": {1}, "2": {1}}, reader.note_range)
+
     def test_implied_labels_get_expanded(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             common.write_json(


### PR DESCRIPTION
The only required field was `annotators` and that can have a reasonable (if not entirely pleasant) default of just using the Label Studio ID as the annotator name.

This way, it's one less friction point to starting to use chart-review. You can always add nice names later.

While here, update the license definition and ruff config.


### Checklist
- [ ] Consider if documentation (like in `docs/`) needs to be updated
- [ ] Consider if tests should be added
