### PR TITLE
Skip over prediction annotations in the export

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,9 @@ jobs:
         with:
           coverageFile: coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          thresholdAll: .99
+          thresholdAll: 1
           thresholdNew: 1
-          thresholdModified: .97
+          thresholdModified: 1
 
   lint:
     runs-on: ubuntu-latest

--- a/chart_review/cohort.py
+++ b/chart_review/cohort.py
@@ -69,7 +69,7 @@ class CohortReader:
                     ls_id = ignore_id  # must be direct note ID
                 else:
                     # Must just be over-zealous excluding (like automatically from SQL)
-                    continue
+                    continue  # pragma: no cover
             if ls_id in all_ls_notes:
                 ignored_notes.add(ls_id)
 

--- a/chart_review/simplify.py
+++ b/chart_review/simplify.py
@@ -35,6 +35,8 @@ def simplify_export(
             labels = defines.LabelSet()
             text_tags = []
             for result in annot.get("result", []):
+                if result.get("origin") not in {None, "manual"}:
+                    continue  # avoid counting predictions as human annotators
                 result_value = result.get("value", {})
                 result_text = result_value.get("text")
                 result_labels = set(result_value.get("labels", []))


### PR DESCRIPTION
Annoyingly, they get put in among the human annotations. But also annoyingly, without enough information to separate them into their own separate robot annotator. But at least we can skip em.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
