### PR TITLE
Merge all export files in the project dir

### DIFF
--- a/chart_review/__init__.py
+++ b/chart_review/__init__.py
@@ -1,3 +1,3 @@
-"""Chart Review public entry point"""
+"""Medical Record Chart Review Calculator"""
 
 __version__ = "1!0.0.0"

--- a/chart_review/cli_utils.py
+++ b/chart_review/cli_utils.py
@@ -17,9 +17,7 @@ def add_project_args(parser: argparse.ArgumentParser, is_global: bool = False) -
         "-p",
         default=None if is_global else argparse.SUPPRESS,
         metavar="DIR",
-        help=(
-            "directory holding project files, like labelstudio-export.json (default: current dir)"
-        ),
+        help=("directory holding project files, like a Label Studio export (default: current dir)"),
     )
     group.add_argument(
         "--config",

--- a/chart_review/cohort.py
+++ b/chart_review/cohort.py
@@ -18,7 +18,7 @@ class CohortReader:
         self.project_dir = self.config.project_dir
 
         # Load exported annotations
-        self.ls_export = studio.ExportFile(self.config.path("labelstudio-export.json"))
+        self.ls_export = studio.ExportFile(self.config.project_dir)
 
         self.annotations = simplify.simplify_export(self.ls_export, self.config)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,8 +15,8 @@ nav_order: 1
 ## Make Project Directory
 
 1. Make a new directory to hold your project files.
-2. Export your Label Studio project and put the resulting JSON file
-   in this directory with the name `labelstudio-export.json`.
+2. Export your Label Studio project as a JSON file and put the exported file
+   in this directory (name it as you like, it will automatically be detected).
 3. Create a [config file](config.md) in this directory.
 
 ## Run Chart Review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "rich",
     "scipy",
 ]
-description = "Medical Record Chart Review Calculator"
 readme = "README.md"
 license = "Apache-2.0"
 classifiers = [
@@ -15,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dynamic = ["version"]
+dynamic = ["description", "version"]
 
 [project.urls]
 Home = "https://smarthealthit.org/cumulus/"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -48,7 +48,7 @@ class TestLabels(base.TestCase):
             )
             common.write_json(
                 f"{tmpdir}/labelstudio-export.json",
-                [],
+                [{"id": 1}],
             )
             stdout = self.run_cli("labels", path=tmpdir)
 

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -74,3 +74,132 @@ class TestStudio(base.TestCase):
             tmpfile.flush()
             with self.assertRaisesRegex(ValueError, "Unrecognized sublabel ID 'bogus-id'."):
                 studio.ExportFile(tmpfile.name)
+
+    def test_merging(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(f"{tmpdir}/one.json", "w", encoding="utf8") as f:
+                json.dump(
+                    [
+                        {
+                            "id": 1,
+                            "annotations": [
+                                {
+                                    "completed_by": 1,
+                                    "result": [{"value": {"labels": ["LabelA"]}}],
+                                },
+                                {
+                                    "completed_by": 2,
+                                    "result": [{"value": {"labels": ["LabelB"]}}],
+                                },
+                            ],
+                            "data": {
+                                "docref_mappings": {"A": "anonA", "B": "anonB"},
+                            },
+                        },
+                    ],
+                    f,
+                )
+            with open(f"{tmpdir}/two.json", "w", encoding="utf8") as f:
+                json.dump(
+                    [
+                        {
+                            "id": 2,
+                            "annotations": [
+                                {
+                                    "completed_by": 1,
+                                    "result": [{"value": {"labels": ["LabelC"]}}],
+                                },
+                                {
+                                    "completed_by": 3,
+                                    "result": [{"value": {"labels": ["LabelD"]}}],
+                                },
+                            ],
+                            "data": {
+                                "docref_mappings": {"A": "anonA", "B": "anonB"},
+                            },
+                        },
+                    ],
+                    f,
+                )
+            with open(f"{tmpdir}/three.json", "w", encoding="utf8") as f:
+                json.dump(
+                    [
+                        {
+                            "id": 3,
+                            "annotations": [
+                                {
+                                    "completed_by": 1,
+                                    "result": [{"value": {"labels": ["LabelE"]}}],
+                                },
+                            ],
+                            "data": {
+                                # Will not be merged, because this doesn't fully match other notes
+                                "docref_mappings": {"A": "anonA"},
+                            },
+                        },
+                    ],
+                    f,
+                )
+
+            merged = studio.ExportFile(tmpdir)
+
+        self.assertEqual(
+            merged.notes,
+            [
+                studio.Note.parse(
+                    {
+                        "id": 1,
+                        "annotations": [
+                            {
+                                "completed_by": 1,
+                                "result": [
+                                    {"value": {"labels": ["LabelA"]}},
+                                    {"value": {"labels": ["LabelC"]}},
+                                ],
+                            },
+                            {
+                                "completed_by": 2,
+                                "result": [{"value": {"labels": ["LabelB"]}}],
+                            },
+                            {
+                                "completed_by": 3,
+                                "result": [{"value": {"labels": ["LabelD"]}}],
+                            },
+                        ],
+                        "data": {
+                            "docref_mappings": {"A": "anonA", "B": "anonB"},
+                        },
+                    }
+                ),
+                studio.Note.parse(
+                    {
+                        "id": 3,
+                        "annotations": [
+                            {
+                                "completed_by": 1,
+                                "result": [{"value": {"labels": ["LabelE"]}}],
+                            },
+                        ],
+                        "data": {
+                            "docref_mappings": {"A": "anonA"},
+                        },
+                    }
+                ),
+            ],
+        )
+
+    def test_bad_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(f"{tmpdir}/invalid.json", "w", encoding="utf8") as f:
+                f.write('[{"id": ]')
+            with open(f"{tmpdir}/strings.json", "w", encoding="utf8") as f:
+                f.write('["string list"]')
+            with open(f"{tmpdir}/no-id.json", "w", encoding="utf8") as f:
+                f.write('[{"random": "yup"}]')
+            with open(f"{tmpdir}/valid.json", "w", encoding="utf8") as f:
+                f.write('[{"id": 1}]')
+
+            self.assertEqual(
+                studio.ExportFile(tmpdir).notes,
+                [studio.Note.parse({"id": 1})],
+            )


### PR DESCRIPTION
Before, we'd hardcode the expected filename and only supported one export. But as we encounter more cases where it's handy to split up review tasks among different LS projects, it's nice to be able to merge exports.

It's also nice to not have to rely on the user naming the file a specific thing.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
