### PR TITLE
Tweak how wildcard labels are specified in config files

### DIFF
--- a/chart_review/config.py
+++ b/chart_review/config.py
@@ -60,6 +60,11 @@ class ProjectConfig:
             group_label = defines.Label.parse(key)
             self.grouped_labels[group_label] = defines.LabelMatcher(*value)
 
+        # ** List of project labels **
+        self.class_labels = defines.LabelMatcher(*self._data.setdefault("labels", []))
+        # Validate that we don't have any partial labels like A|B by constructing them all:
+        self.class_labels.direct_labels()
+
     def path(self, filename: str) -> str:
         return os.path.join(self.project_dir, filename)
 
@@ -106,10 +111,6 @@ class ProjectConfig:
         else:
             print(f"Unknown note range '{value}'", file=sys.stderr)
             return []
-
-    @property
-    def class_labels(self) -> defines.LabelSet:
-        return set(defines.Label.parse(x) for x in self._data.setdefault("labels", []))
 
     @property
     def ignore(self) -> set[str]:

--- a/chart_review/simplify.py
+++ b/chart_review/simplify.py
@@ -14,8 +14,7 @@ def simplify_export(
     :return: all project mentions parsed from the Label Studio export
     """
     annotations = defines.ProjectAnnotations()
-    annotations.labels = proj_config.class_labels
-    grab_all_labels = not annotations.labels
+    annotations.labels = proj_config.class_labels.direct_labels()
 
     for note in export.notes:
         for annot in note.annotations:
@@ -30,8 +29,10 @@ def simplify_export(
                 labels |= mention.labels
                 text_tags.append(defines.LabeledText(mention.text, mention.labels))
 
-            if grab_all_labels:
-                annotations.labels |= labels
+            valid_proj_labels = labels
+            if proj_config.class_labels:
+                valid_proj_labels = proj_config.class_labels.matches_in_set(labels)
+            annotations.labels |= valid_proj_labels
 
             # Store these mentions in the main annotations list, by author & note
             annotator_mentions = annotations.mentions.setdefault(annotator, defines.Mentions())

--- a/docs/config.md
+++ b/docs/config.md
@@ -126,12 +126,12 @@ grouped-labels:
 You can also use partial "wildcard" matches on the right hand side:
 ```yaml
 grouped-labels:
-  Had Infection: [Infection|Severity]
+  Had Infection: [Infection|Severity|*]
 ```
 Or:
 ```yaml
 grouped-labels:
-  Had Infection: [Infection]
+  Had Infection: [Infection|*]
 ```
 
 ### `ignore`
@@ -183,12 +183,12 @@ implied-labels:
 You can also use partial "wildcard" matches on the left hand side:
 ```yaml
 implied-labels:
-  Infection|Severity: [Had Infection]
+  Infection|Severity|*: [Had Infection]
 ```
 Or:
 ```yaml
 implied-labels:
-  Infection: [Had Infection]
+  Infection|*: [Had Infection]
 ```
 
 ### `labels`
@@ -220,6 +220,17 @@ For example: a "Infection" label with a sublabel of "Severity" and a choice valu
 labels:
   - Infection | Severity | Mild
   - Infection | Severity | Severe
+```
+
+You can also use partial "wildcard" matches against the labels found in the export:
+```yaml
+labels:
+  - Infection|Severity|*
+```
+Or:
+```yaml
+labels:
+  - Infection|*
 ```
 
 ### `ranges`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,7 +50,9 @@ class TestProjectConfig(base.TestCase):
         """Verify that we can operate on multiple formats (like json & yaml)."""
         proj_config = self.make_config(text, filename=f"config.{suffix}")
 
-        self.assertEqual(base.labels({"cough|cough|sever", "fever"}), proj_config.class_labels)
+        self.assertEqual(
+            base.labels({"cough|cough|sever", "fever"}), proj_config.class_labels.direct_labels()
+        )
         self.assertEqual({1: "jane", 2: "john"}, proj_config.annotators)
         self.assertEqual({"jane": [3], "john": [1, 3, 5]}, proj_config.note_ranges)
 
@@ -126,7 +128,7 @@ class TestProjectConfig(base.TestCase):
     def test_label_with_extra_pipes(self):
         """They get put with the value side of things"""
         proj_config = self.make_config("labels: [A|B|C|D]")
-        self.assertEqual(proj_config.class_labels, {base.Label("A", "B", "C|D")})
+        self.assertEqual(proj_config.class_labels.direct_labels(), {base.Label("A", "B", "C|D")})
 
     def test_label_with_pipes_in_key_part(self):
         """They are not allowed"""

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -66,10 +66,12 @@ class TestSimplify(base.TestCase):
     @ddt.data(
         (["A|B|C"], ["A|B|C"], True),
         (["A|B|D"], ["A|B|C"], False),
-        (["A|B|C"], ["A|B"], True),
-        (["A|C|D"], ["A|B"], False),
-        (["A|B|C"], ["A"], True),
-        (["B|C|D"], ["A"], False),
+        (["A|B|C"], ["A|B"], False),
+        (["A|B|C"], ["A|B|*"], True),
+        (["A|C|D"], ["A|B|*"], False),
+        (["A|B|C"], ["A"], False),
+        (["A|B|C"], ["A|*"], True),
+        (["B|C|D"], ["A|*"], False),
     )
     @ddt.unpack
     def test_sublabel_implied_matching(self, labels, config, add_to_expected):
@@ -86,8 +88,8 @@ class TestSimplify(base.TestCase):
         self.assertEqual(annotations.labels, labels)
 
     @ddt.data(
-        (["A"], ["Group", "H"]),
-        (["A|B"], ["Group", "H", "A|M|N"]),
+        (["A|*"], ["Group", "H"]),
+        (["A|B|*"], ["Group", "H", "A|M|N"]),
         (["A|B|C"], ["Group", "H", "A|B|D", "A|M|N"]),
     )
     @ddt.unpack


### PR DESCRIPTION
You now must explicitly flag it as a wildcard label with an asterisk. So like A|* or A|B|*.

This is a breaking change, but I don't think anyone is using this yet. So :shrug:

This commit also allows you to use wildcard labels in the labels: config section, to match any of the found labels. That should help with initial exploration of labels, but note that if a label is not in the source export, it won't be in the final results this way. So it's still best to be explicit where possible.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
