### PR TITLE
accuracy: add aggregate sublabel rows

### DIFF
--- a/chart_review/agree.py
+++ b/chart_review/agree.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection, Iterable
+from collections.abc import Collection
 
 from chart_review import defines
 
@@ -8,7 +8,7 @@ def confusion_matrix(
     truth: str,
     annotator: str,
     note_range: Collection[int],
-    labels: Iterable[str] | None = None,
+    labels: defines.LabelSet | None = None,
 ) -> dict[str, list]:
     """
     Confusion Matrix (TP, FP, TN, FN)
@@ -36,7 +36,7 @@ def confusion_matrix(
     for _v in annotator_mentions.values():
         label_set |= set(_v)
     if labels:
-        label_set &= set(labels)
+        label_set &= labels
 
     TP = list()  # True Positive
     FP = list()  # False Positive
@@ -185,7 +185,7 @@ def contingency_table(
     annotator1: str,
     annotator2: str,
     note_range: Collection[int],
-    labels: Iterable[str] | None = None,
+    labels: defines.LabelSet | None = None,
 ) -> dict[str, list]:
     # Grab all mentions
     mentions = {
@@ -199,7 +199,7 @@ def contingency_table(
         for mention_labels in mentions_set.values():
             label_set |= set(mention_labels)
     if labels:
-        label_set &= set(labels)
+        label_set &= labels
 
     BC = []  # both correct
     OL = []  # only left

--- a/chart_review/cohort.py
+++ b/chart_review/cohort.py
@@ -1,5 +1,3 @@
-from collections.abc import Iterable
-
 from chart_review import agree, config, defines, external, simplify, studio
 
 
@@ -80,18 +78,22 @@ class CohortReader:
     def class_labels(self) -> defines.LabelSet:
         return self.annotations.labels
 
-    def _select_labels(self, label_pick: str | None = None) -> Iterable[str]:
-        if label_pick:
-            return [label_pick]
-        else:
+    def _select_labels(
+        self, label_pick: defines.Label | defines.LabelMatcher | None = None
+    ) -> defines.LabelSet:
+        if label_pick is None:
             return self.class_labels
+        elif isinstance(label_pick, defines.LabelMatcher):
+            return label_pick.matches_in_set(self.class_labels)
+        else:
+            return {label_pick}
 
     def confusion_matrix(
         self,
         truth: str,
         annotator: str,
         note_range: defines.NoteSet,
-        label_pick: str | None = None,
+        label_pick: defines.Label | defines.LabelMatcher | None = None,
     ) -> dict:
         """
         This is the rollup of counting each symptom only once, not multiple times.
@@ -117,7 +119,7 @@ class CohortReader:
         annotator1: str,
         annotator2: str,
         note_range: defines.NoteSet,
-        label_pick: str | None = None,
+        label_pick: defines.Label | defines.LabelMatcher | None = None,
     ) -> dict:
         """
         Calculate a contingency table for truth and two annotators.

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -199,13 +199,17 @@ Macro F1: 0.375
 F1   Sens  Spec   PPV  NPV    Kappa  TP  FN  TN  FP  Label                      
 0.6  0.6   0.778  0.6  0.778  0.378  3   2   7   2   *                          
 0    0     0      0    0      0      0   1   1   0   Deceased                   
+1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Deceased → *               
 1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Deceased → False           
+0    0     0      0    0      0      0   1   2   1   Deceased → Datetime → *    
 0    0     0      0    0      0      0   1   1   0   Deceased → Datetime →      
                                                      11/12/25                   
 0    0     0      0    0      0      0   0   1   1   Deceased → Datetime →      
                                                      11/13/25                   
+1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Fungal → *                 
 1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Fungal → Confirmed         
 0    0     0      0    0      0      0   0   1   1   Infection                  
+1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Infection → *              
 0    0     0      0    0      0      0   0   0   0   Infection → Confirmed      
 1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Infection → Suspected      
 """,

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -16,10 +16,10 @@ class TestAgreement(base.TestCase):
             "bob",
             None,
             {
-                "FN": [{1: "Cough"}],
-                "FP": [{1: "Headache"}, {2: "Cough"}],
-                "TN": [{1: "Fever"}, {2: "Headache"}],
-                "TP": [{2: "Fever"}],
+                "FN": [{1: base.Label("Cough")}],
+                "FP": [{1: base.Label("Headache")}, {2: base.Label("Cough")}],
+                "TN": [{1: base.Label("Fever")}, {2: base.Label("Headache")}],
+                "TP": [{2: base.Label("Fever")}],
             },
         ),
         (
@@ -27,19 +27,19 @@ class TestAgreement(base.TestCase):
             "alice",
             {},
             {
-                "FN": [{1: "Headache"}, {2: "Cough"}],
-                "FP": [{1: "Cough"}],
-                "TN": [{1: "Fever"}, {2: "Headache"}],
-                "TP": [{2: "Fever"}],
+                "FN": [{1: base.Label("Headache")}, {2: base.Label("Cough")}],
+                "FP": [{1: base.Label("Cough")}],
+                "TN": [{1: base.Label("Fever")}, {2: base.Label("Headache")}],
+                "TP": [{2: base.Label("Fever")}],
             },
         ),
         (
             "alice",
             "bob",
-            ["Cough"],
+            base.labels(["Cough"]),
             {
-                "FN": [{1: "Cough"}],
-                "FP": [{2: "Cough"}],
+                "FN": [{1: base.Label("Cough")}],
+                "FP": [{2: base.Label("Cough")}],
                 "TN": [],
                 "TP": [],
             },
@@ -51,8 +51,8 @@ class TestAgreement(base.TestCase):
         annotations = defines.ProjectAnnotations(
             labels={"Cough", "Fever", "Headache"},
             mentions={
-                "alice": {1: {"Cough"}, 2: {"Fever"}},
-                "bob": {1: {"Headache"}, 2: {"Cough", "Fever"}},
+                "alice": {1: base.labels({"Cough"}), 2: base.labels({"Fever"})},
+                "bob": {1: base.labels({"Headache"}), 2: base.labels({"Cough", "Fever"})},
             },
         )
         notes = [1, 2]


### PR DESCRIPTION
Example output:
```
Comparing 2 charts (1308–1309)
Truth: alice
Annotator: bob
Macro F1: 0.375

F1   Sens  Spec   PPV  NPV    Kappa  TP  FN  TN  FP  Label                      
0.6  0.6   0.778  0.6  0.778  0.378  3   2   7   2   *                          
0    0     0      0    0      0      0   1   1   0   Deceased                   
1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Deceased → *               
1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Deceased → False           
0    0     0      0    0      0      0   1   2   1   Deceased → Datetime → *    
0    0     0      0    0      0      0   1   1   0   Deceased → Datetime →      
                                                     11/12/25                   
0    0     0      0    0      0      0   0   1   1   Deceased → Datetime →      
                                                     11/13/25                   
1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Fungal → *                 
1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Fungal → Confirmed         
0    0     0      0    0      0      0   0   1   1   Infection                  
1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Infection → *              
0    0     0      0    0      0      0   0   0   0   Infection → Confirmed      
1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Infection → Suspected      
```

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
