### PR TITLE
Calculate the stats we can, instead of bailing on whole row

### DIFF
--- a/chart_review/cli_utils.py
+++ b/chart_review/cli_utils.py
@@ -31,9 +31,7 @@ def add_project_args(parser: argparse.ArgumentParser, is_global: bool = False) -
 def add_output_args(parser: argparse.ArgumentParser):
     """Returns an exclusive option group if you want to add custom output arguments"""
     group = parser.add_argument_group("output")
-    exclusive = group.add_mutually_exclusive_group()
-    exclusive.add_argument("--csv", action="store_true", help="print results in CSV format")
-    return exclusive
+    group.add_argument("--csv", action="store_true", help="print results in CSV format")
 
 
 def get_cohort_reader(args: argparse.Namespace) -> cohort.CohortReader:
@@ -68,4 +66,7 @@ def print_table_as_csv(table: rich.table.Table) -> None:
     # And then each row
     cells_by_row = zip(*[col.cells for col in table.columns])
     for row in cells_by_row:
+        # Turn hyphens into empty csv entries (handled as null/NaN),
+        # so that our float columns aren't interpreted as a string column.
+        row = ["" if cell == "-" else cell for cell in row]
         writer.writerow(row)

--- a/chart_review/common.py
+++ b/chart_review/common.py
@@ -33,18 +33,6 @@ def write_json(path: str, data: dict | list, indent: int | None = 4) -> None:
         json.dump(data, f, indent=indent)
 
 
-def read_text(path: str) -> str:
-    """
-    Reads data from the given path, in text format
-    :param path: (currently filesystem path)
-    :return: message: coded message
-    """
-    logging.debug("read_text() %s", path)
-
-    with open(path) as f:
-        return f.read()
-
-
 def write_text(path: str, text: str) -> None:
     """
     Writes data to the given path, in text format

--- a/docs/accuracy.md
+++ b/docs/accuracy.md
@@ -21,13 +21,13 @@ $ chart-review accuracy jill jane
 Comparing 3 charts (1, 3–4)
 Truth: jill
 Annotator: jane
-Macro F1: 0.556
+Macro F1: 0.833
 
-F1     Sens  Spec  PPV  NPV   Kappa  TP  FN  TN  FP  Label   
-0.667  0.75  0.6   0.6  0.75  0.341  3   1   3   2   *       
-0.667  0.5   1.0   1.0  0.5   0.4    1   1   1   0   Cough   
-1.0    1.0   1.0   1.0  1.0   1.0    2   0   1   0   Fatigue 
-0      0     0     0    0     0      0   0   1   2   Headache
+F1     Sens  Spec   PPV  NPV   Kappa  TP  FN  TN  FP  Label   
+0.667  0.75  0.6    0.6  0.75  0.341  3   1   3   2   *       
+0.667  0.5   1.0    1.0  0.5   0.4    1   1   1   0   Cough   
+1.0    1.0   1.0    1.0  1.0   1.0    2   0   1   0   Fatigue 
+-      -     0.333  0.0  1.0   0.0    0   0   1   2   Headache
 ```
 
 ## Options
@@ -76,7 +76,7 @@ f1,sens,spec,ppv,npv,kappa,tp,fn,tn,fp,label
 0.667,0.75,0.6,0.6,0.75,0.341,3,1,3,2,*
 0.667,0.5,1.0,1.0,0.5,0.4,1,1,1,0,Cough
 1.0,1.0,1.0,1.0,1.0,1.0,2,0,1,0,Fatigue
-0,0,0,0,0,0,0,0,1,2,Headache
+,,0.333,0.0,1.0,0.0,0,0,1,2,Headache
 ```
 
 ```shell

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,9 +1,5 @@
 """Tests for commands/accuracy.py"""
 
-import shutil
-import tempfile
-
-from chart_review import common
 from tests import base
 
 
@@ -17,13 +13,13 @@ class TestAccuracy(base.TestCase):
             """Comparing 3 charts (1, 3–4)
 Truth: jill
 Annotator: jane
-Macro F1: 0.556
+Macro F1: 0.833
 
-F1     Sens  Spec  PPV  NPV   Kappa  TP  FN  TN  FP  Label   
-0.667  0.75  0.6   0.6  0.75  0.341  3   1   3   2   *       
-0.667  0.5   1.0   1.0  0.5   0.4    1   1   1   0   Cough   
-1.0    1.0   1.0   1.0  1.0   1.0    2   0   1   0   Fatigue 
-0      0     0     0    0     0      0   0   1   2   Headache
+F1     Sens  Spec   PPV  NPV   Kappa  TP  FN  TN  FP  Label   
+0.667  0.75  0.6    0.6  0.75  0.341  3   1   3   2   *       
+0.667  0.5   1.0    1.0  0.5   0.4    1   1   1   0   Cough   
+1.0    1.0   1.0    1.0  1.0   1.0    2   0   1   0   Fatigue 
+-      -     0.333  0.0  1.0   0.0    0   0   1   2   Headache
 """,
             stdout,
         )
@@ -37,87 +33,10 @@ F1     Sens  Spec  PPV  NPV   Kappa  TP  FN  TN  FP  Label
                 "0.667,0.75,0.6,0.6,0.75,0.341,3,1,3,2,*",
                 "0.667,0.5,1.0,1.0,0.5,0.4,1,1,1,0,Cough",
                 "1.0,1.0,1.0,1.0,1.0,1.0,2,0,1,0,Fatigue",
-                "0,0,0,0,0,0,0,0,1,2,Headache",
+                ",,0.333,0.0,1.0,0.0,0,0,1,2,Headache",
             ],
             stdout.splitlines(),
         )
-
-    def test_save(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            shutil.copytree(f"{self.DATA_DIR}/cold", tmpdir, dirs_exist_ok=True)
-            self.run_cli("accuracy", "--save", "jill", "jane", path=tmpdir)
-
-            accuracy_json = common.read_json(f"{tmpdir}/accuracy-jill-jane.json")
-            self.assertEqual(
-                {
-                    "F1": 0.667,
-                    "Sens": 0.75,
-                    "Spec": 0.6,
-                    "PPV": 0.6,
-                    "NPV": 0.75,
-                    "Kappa": 0.341,
-                    "TP": 3,
-                    "FN": 1,
-                    "TN": 3,
-                    "FP": 2,
-                    "Cough": {
-                        "F1": 0.667,
-                        "FN": 1,
-                        "FP": 0,
-                        "NPV": 0.5,
-                        "PPV": 1.0,
-                        "Sens": 0.5,
-                        "Spec": 1.0,
-                        "TN": 1,
-                        "TP": 1,
-                        "Kappa": 0.4,
-                    },
-                    "Fatigue": {
-                        "F1": 1.0,
-                        "FN": 0,
-                        "FP": 0,
-                        "NPV": 1.0,
-                        "PPV": 1.0,
-                        "Sens": 1.0,
-                        "Spec": 1.0,
-                        "TN": 1,
-                        "TP": 2,
-                        "Kappa": 1.0,
-                    },
-                    "Headache": {
-                        "F1": 0,
-                        "FN": 0,
-                        "FP": 2,
-                        "NPV": 0,
-                        "PPV": 0,
-                        "Sens": 0,
-                        "Spec": 0,
-                        "TN": 1,
-                        "TP": 0,
-                        "Kappa": 0,
-                    },
-                },
-                accuracy_json,
-            )
-
-            accuracy_csv = common.read_text(f"{tmpdir}/accuracy-jill-jane.csv")
-            self.assertEqual(
-                """F1	Sens	Spec	PPV	NPV	Kappa	TP	FN	TN	FP	Label
-0.667	0.75	0.6	0.6	0.75	0.341	3	1	3	2	*
-0.667	0.5	1.0	1.0	0.5	0.4	1	1	1	0	Cough
-1.0	1.0	1.0	1.0	1.0	1.0	2	0	1	0	Fatigue
-0	0	0	0	0	0	0	0	1	2	Headache
-""",
-                accuracy_csv,
-            )
-
-    def test_save_and_csv_conflict(self):
-        """Verify that --save and --csv can't run together"""
-        with self.assertRaises(SystemExit) as cm:
-            self.run_cli(
-                "accuracy", "--save", "--csv", "jill", "jane", path=f"{self.DATA_DIR}/cold"
-            )
-        self.assertEqual(2, cm.exception.code)
 
     def test_verbose(self):
         output = self.run_cli("accuracy", "--verbose", "jill", "jane", path=f"{self.DATA_DIR}/cold")
@@ -194,23 +113,23 @@ Annotator: jane
             """Comparing 2 charts (1308–1309)
 Truth: alice
 Annotator: bob
-Macro F1: 0.375
+Macro F1: 1.0
 
-F1   Sens  Spec   PPV  NPV    Kappa  TP  FN  TN  FP  Label                      
-0.6  0.6   0.778  0.6  0.778  0.378  3   2   7   2   *                          
-0    0     0      0    0      0      0   1   1   0   Deceased                   
-1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Deceased → *               
-1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Deceased → False           
-0    0     0      0    0      0      0   1   2   1   Deceased → Datetime → *    
-0    0     0      0    0      0      0   1   1   0   Deceased → Datetime →      
-                                                     11/12/25                   
-0    0     0      0    0      0      0   0   1   1   Deceased → Datetime →      
-                                                     11/13/25                   
-1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Fungal → *                 
-1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Fungal → Confirmed         
-0    0     0      0    0      0      0   0   1   1   Infection                  
-1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Infection → *              
-0    0     0      0    0      0      0   0   0   0   Infection → Confirmed      
-1.0  1.0   1.0    1.0  1.0    1.0    1   0   1   0   Infection → Suspected      
+F1   Sens  Spec   PPV  NPV    Kappa   TP  FN  TN  FP  Label                     
+0.6  0.6   0.778  0.6  0.778  0.378   3   2   7   2   *                         
+-    0.0   1.0    -    0.5    0.0     0   1   1   0   Deceased                  
+1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Deceased → *              
+1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Deceased → False          
+-    0.0   0.667  0.0  0.667  -0.333  0   1   2   1   Deceased → Datetime → *   
+-    0.0   1.0    -    0.5    0.0     0   1   1   0   Deceased → Datetime →     
+                                                      11/12/25                  
+-    -     0.5    0.0  1.0    0.0     0   0   1   1   Deceased → Datetime →     
+                                                      11/13/25                  
+1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Fungal → *                
+1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Fungal → Confirmed        
+-    -     0.5    0.0  1.0    0.0     0   0   1   1   Infection                 
+1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Infection → *             
+-    -     -      -    -      -       0   0   0   0   Infection → Confirmed     
+1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Infection → Suspected     
 """,
         )


### PR DESCRIPTION
Also, make the difference between "can't calculate" and "zero" clearer. When printing to csv, make "can't calculate" an empty cell. When printing to console, make "can't calculate" a hyphen.

Also, finally drop the deprecated --save argument. It was annoying to update for this new treatment, so I dropped it.

And finally, when calculating Macro F1, skip null results.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
