### PR TITLE
Bugfix: unbalanced data no longer breaks kappa computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /site/
 __pycache__/
 /venv
+/.vscode

--- a/chart_review/agree.py
+++ b/chart_review/agree.py
@@ -91,6 +91,10 @@ def score_kappa(matrix: dict) -> float:
     expected_neg = ((tn + fp) / total) * ((tn + fn) / total)
     expected = expected_pos + expected_neg
 
+    # If we encounter a divide-by-zero, return NaN
+    if math.isclose(1 - expected, 0.0):
+        return math.nan
+
     return (observed - expected) / (1 - expected)
 
 

--- a/chart_review/agree.py
+++ b/chart_review/agree.py
@@ -92,6 +92,7 @@ def score_kappa(matrix: dict) -> float:
     expected = expected_pos + expected_neg
 
     # If we encounter a divide-by-zero, return NaN
+    # Using math.isclose to handle floating point precision issues
     if math.isclose(1 - expected, 0.0):
         return math.nan
 

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -1,5 +1,7 @@
 """Tests for agree.py"""
 
+import math
+
 import ddt
 
 from chart_review import agree, defines
@@ -105,3 +107,28 @@ class TestAgreement(base.TestCase):
         """Verify that we can score a matrix for kappa."""
         kappa = round(agree.score_kappa(matrix), 4)
         self.assertEqual(expected_kappa, kappa)
+
+    @ddt.data(
+        # Example of incredibly unbalanced data, as a regression test
+        (
+            {
+                "FN": [],
+                "FP": [],
+                "TN": [{x: "Label"} for x in range(90)],
+                "TP": [],
+            },
+        ),
+        (
+            {
+                "FN": [],
+                "FP": [],
+                "TN": [],
+                "TP": [{x: "Label"} for x in range(90)],
+            },
+        ),
+    )
+    @ddt.unpack
+    def test_unbalanced_kappa(self, matrix):
+        """Verify that kappa will handle unbalanced NaN cases."""
+        kappa = round(agree.score_kappa(matrix), 4)
+        self.assertEqual(math.isnan(kappa), True)


### PR DESCRIPTION
### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added

Previously, extremely unbalanced data with total agreement on a positive label between annotators (All TP; 0 everything else) would cause a divide-by-zero failure case. This was seen on one of the small tasks Andy and I previously worked on annotating MultipleTransplantHistory. This PR adds a guard for, returning NaN, that and adds a regression test ensuring that's the case. 