### PR TITLE
Support DateTime labels

### DIFF
--- a/chart_review/studio.py
+++ b/chart_review/studio.py
@@ -30,13 +30,6 @@ class Mention:
     def parse(entry: dict) -> "Mention":
         # Check where we're going to find the labels/tags
         match entry.get("type", "labels").casefold():
-            case "labels":
-                # Looks like:
-                # "value": {
-                #   "text": "patient has infection",
-                #   "labels": ["Infection"]
-                # },
-                field = "labels"
             case "choices":
                 # Looks like:
                 # "value": {
@@ -44,18 +37,42 @@ class Mention:
                 #   "choices": ["False"]
                 # },
                 field = "choices"
+                is_list = True
+            case "datetime":
+                # Looks like:
+                # "value": {
+                #   "text": "Nov 15",
+                #   "datetime": "2018-11-15",
+                # },
+                field = "datetime"
+                is_list = False
+            case "labels":
+                # Looks like:
+                # "value": {
+                #   "text": "patient has infection",
+                #   "labels": ["Infection"]
+                # },
+                field = "labels"
+                is_list = True
             case "textarea":
                 # Looks like:
                 # "value": {
                 #   "text": ["free form"],
                 # },
                 field = "text"
+                is_list = True
             case _:
                 raise ValueError(f"Unrecognized Label Studio result type '{entry.get('type')}'.")
 
         value = entry.get("value", {})
         text = value.get("text", "") if field != "text" else ""
-        labels = set(defines.Label(x) for x in value.get(field, []))
+        field_value = value.get(field)
+        if not field_value:
+            labels = set()
+        elif is_list:
+            labels = {defines.Label(x) for x in field_value}
+        else:
+            labels = {defines.Label(field_value)}
         return Mention(
             id=entry.get("id", ""), text=text, labels=labels, from_name=entry.get("from_name", "")
         )

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -203,3 +203,54 @@ class TestStudio(base.TestCase):
                 studio.ExportFile(tmpdir).notes,
                 [studio.Note.parse({"id": 1})],
             )
+
+    def test_supported_types(self):
+        with tempfile.NamedTemporaryFile("wt") as tmpfile:
+            json.dump(
+                [
+                    {
+                        "id": 1,
+                        "annotations": [
+                            {
+                                "completed_by": 1,
+                                "result": [
+                                    {
+                                        "value": {"choices": ["Choice"]},
+                                        "type": "choices",
+                                    },
+                                    {
+                                        "value": {"datetime": "2021-04-22"},
+                                        "type": "datetime",
+                                    },
+                                    {
+                                        "value": {"datetime": "2021-04-22T10:20:30Z"},
+                                        "type": "datetime",
+                                    },
+                                    {
+                                        "value": {"labels": ["Label"]},
+                                        "type": "labels",
+                                    },
+                                    {
+                                        "value": {"text": ["Text"]},
+                                        "type": "textarea",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                tmpfile,
+            )
+            tmpfile.flush()
+            export = studio.ExportFile(tmpfile.name)
+
+        self.assertEqual(
+            [x.labels for x in export.notes[0].annotations[0].mentions],
+            [
+                base.labels(["Choice"]),
+                base.labels(["2021-04-22"]),
+                base.labels(["2021-04-22T10:20:30Z"]),
+                base.labels(["Label"]),
+                base.labels(["Text"]),
+            ],
+        )


### PR DESCRIPTION
For now, just read in the value as a string. Later, if/when we add interpretation of dates, we can get fancier. But this at least supports the field as they come in.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
