### PR TITLE
Ignore labels that *should* have sublabels but don't

### DIFF
--- a/chart_review/commands/accuracy.py
+++ b/chart_review/commands/accuracy.py
@@ -107,3 +107,7 @@ def print_accuracy(args: argparse.Namespace) -> None:
 
     console.print()
     console.print(table)
+
+    console_utils.print_ignored_labels(
+        reader, prefix=None if args.verbose else "\n", annotators={truth, annotator}
+    )

--- a/chart_review/commands/frequency.py
+++ b/chart_review/commands/frequency.py
@@ -72,6 +72,7 @@ def print_frequency(args: argparse.Namespace) -> None:
     else:
         rich.get_console().print(table)
         console_utils.print_ignored_charts(reader)
+        console_utils.print_ignored_labels(reader)
         if has_term_confusion:
             rich.get_console().print(
                 "  * This text has multiple associated labels.", style="italic"

--- a/chart_review/commands/labels.py
+++ b/chart_review/commands/labels.py
@@ -48,3 +48,4 @@ def print_labels(args: argparse.Namespace) -> None:
     else:
         rich.get_console().print(label_table)
         console_utils.print_ignored_charts(reader)
+        console_utils.print_ignored_labels(reader)

--- a/chart_review/commands/mcnemar.py
+++ b/chart_review/commands/mcnemar.py
@@ -90,6 +90,7 @@ def print_mcnemar(args: argparse.Namespace) -> None:
     console.print()
 
     console.print(table)
+    console_utils.print_ignored_labels(reader, prefix="\n", annotators=all_people)
 
 
 def _small_float(number: float) -> str:

--- a/chart_review/commands/mentions.py
+++ b/chart_review/commands/mentions.py
@@ -43,3 +43,4 @@ def print_mentions(args: argparse.Namespace) -> None:
     else:
         rich.get_console().print(table)
         console_utils.print_ignored_charts(reader)
+        console_utils.print_ignored_labels(reader)

--- a/chart_review/console_utils.py
+++ b/chart_review/console_utils.py
@@ -59,3 +59,32 @@ def print_ignored_charts(reader: cohort.CohortReader):
         highlight=False,
         style="italic",
     )
+
+
+def print_ignored_labels(
+    reader: cohort.CohortReader,
+    prefix: str | None = None,
+    annotators: set[str] | None = None,
+):
+    """
+    Prints a line about ignored labels, suitable for underlying a table.
+
+    It's recommended that any CLI command that shows labels or label counts
+    call this for their normal output view (i.e. not a formatted view like --csv).
+    """
+    invalid_count = 0
+    for annotator, mentions in reader.annotations.invalid_mentions.items():
+        if annotators and annotator not in annotators:
+            continue
+        for _chart_id, labels in mentions.items():
+            invalid_count += len(labels)
+    if invalid_count == 0:
+        return
+
+    label_word = "mention" if invalid_count == 1 else "mentions"
+    prefix = "  " if prefix is None else prefix
+    rich.get_console().print(
+        f"{prefix}Ignoring {invalid_count} invalid {label_word}",
+        highlight=False,
+        style="italic",
+    )

--- a/chart_review/defines.py
+++ b/chart_review/defines.py
@@ -146,6 +146,9 @@ class ProjectAnnotations:
     # annotator_name -> Mentions
     mentions: dict[str, Mentions] = dataclasses.field(default_factory=dict)
 
+    # annotator_name -> Mentions
+    invalid_mentions: dict[str, Mentions] = dataclasses.field(default_factory=dict)
+
     # We usually deal with simplified note-wide labels, but sometimes it's helpful to have
     # the original text-to-label associations available, for term frequency analysis.
     # annotators -> note_id -> list of text/label combos
@@ -156,6 +159,9 @@ class ProjectAnnotations:
     def remove(self, chart_id: int):
         # Remove any instance of this chart ID
         for mentions in self.mentions.values():
+            if chart_id in mentions:
+                del mentions[chart_id]
+        for mentions in self.invalid_mentions.values():
             if chart_id in mentions:
                 del mentions[chart_id]
         for mentions in self.original_text_mentions.values():

--- a/chart_review/simplify.py
+++ b/chart_review/simplify.py
@@ -129,3 +129,23 @@ def simplify_mentions(
         annotator: _convert_grouped_mentions(mentions, grouped_labels)
         for annotator, mentions in annotations.mentions.items()
     }
+
+    # Check for any toplevel labels that *should* have a sublabel but don't, and drop them.
+    # e.g. if we saw a sublabel for "LabelA", any "LabelA" instances without a sublabel
+    # are considered invalid and we toss them.
+    # First, make one pass to find all the invalid versions of labels
+    invalid_labels = defines.LabelSet()
+    for annotator, mentions in annotations.mentions.items():
+        for labels in mentions.values():
+            for label in labels:
+                if label.sublabel_value:
+                    invalid_labels.add(defines.Label(label.label))
+    annotations.labels -= invalid_labels
+
+    # Now a second pass to strip invalid labels out
+    for annotator, mentions in annotations.mentions.items():
+        for chart_id, labels in mentions.items():
+            if found_invalid := labels & invalid_labels:
+                new_mention = annotations.invalid_mentions.setdefault(annotator, defines.Mentions())
+                new_mention[chart_id] = found_invalid
+                labels.difference_update(found_invalid)

--- a/chart_review/studio.py
+++ b/chart_review/studio.py
@@ -119,15 +119,15 @@ class Annotation:
         # So you can see there that the "id" field is re-used, and the sublabel refers to the
         # parent via "from_name".
 
-        # When parsing here, we'll first look for the toplevel entries (identifiable by a
-        # "from_name" pointing at a key in data_keys). Then do a second pass for any sublabels and
-        # adjust the parent with the extra info.
+        # When parsing here, we'll first look for the toplevel entries (the first use of any given
+        # "id" value). Then do a second pass for any sublabels and adjust the parent with the extra
+        # info.
         mentions: list[Mention] = []
         toplevels: dict[str, Mention] = {}
         sublabels: list[Mention] = []
         for result in entry.get("result", []):
             mention = Mention.parse(result)
-            if not mention.from_name or mention.from_name in data_keys:
+            if not mention.id or mention.id not in toplevels:
                 # This is a toplevel mention
                 toplevels[mention.id] = mention
                 mentions.append(mention)
@@ -138,8 +138,6 @@ class Annotation:
         # Now match up the sublabels
         base_sets: dict[str, defines.LabelSet] = {}
         for sublabel in sublabels:
-            if sublabel.id not in toplevels:
-                raise ValueError(f"Unrecognized sublabel ID '{sublabel.id}'.")
             toplevel = toplevels[sublabel.id]
 
             # Wipe out any toplevel tags (existence of a sublabel implies no toplevel labels)

--- a/tests/data/ignore/labelstudio-export.json
+++ b/tests/data/ignore/labelstudio-export.json
@@ -106,7 +106,7 @@
           {
             "value": {
               "labels": [
-                "A"
+                "Recorded On"
               ]
             }
           }
@@ -131,11 +131,19 @@
         "completed_by": 1,
         "result": [
           {
+            "id": "xyz",
             "value": {
               "labels": [
-                "A"
+                "Recorded On"
               ]
             }
+          },
+          {
+            "id": "xyz",
+            "value": {
+              "datetime": "2025-10-10"
+            },
+            "type": "datetime"
           }
         ]
       },

--- a/tests/data/sublabels/labelstudio-export.json
+++ b/tests/data/sublabels/labelstudio-export.json
@@ -174,17 +174,6 @@
             "to_name": "text",
             "type": "textarea",
             "origin": "manual"
-          },
-          {
-            "value": {
-              "text": "death",
-              "labels": ["Infection"]
-            },
-            "id": "EW1f64rW6m",
-            "from_name": "label",
-            "to_name": "text",
-            "type": "labels",
-            "origin": "manual"
           }
         ]
       },
@@ -266,6 +255,17 @@
             "from_name": "Deceased Datetime",
             "to_name": "text",
             "type": "textarea",
+            "origin": "manual"
+          },
+          {
+            "value": {
+              "text": "death",
+              "labels": ["Infection"]
+            },
+            "id": "EW1f64rW6m",
+            "from_name": "label",
+            "to_name": "text",
+            "type": "labels",
             "origin": "manual"
           }
         ]

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -115,21 +115,21 @@ Truth: alice
 Annotator: bob
 Macro F1: 1.0
 
-F1   Sens  Spec   PPV  NPV    Kappa   TP  FN  TN  FP  Label                     
-0.6  0.6   0.778  0.6  0.778  0.378   3   2   7   2   *                         
--    0.0   1.0    -    0.5    0.0     0   1   1   0   Deceased                  
-1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Deceased → *              
-1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Deceased → False          
--    0.0   0.667  0.0  0.667  -0.333  0   1   2   1   Deceased → Datetime → *   
--    0.0   1.0    -    0.5    0.0     0   1   1   0   Deceased → Datetime →     
-                                                      11/12/25                  
--    -     0.5    0.0  1.0    0.0     0   0   1   1   Deceased → Datetime →     
-                                                      11/13/25                  
-1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Fungal → *                
-1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Fungal → Confirmed        
--    -     0.5    0.0  1.0    0.0     0   0   1   1   Infection                 
-1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Infection → *             
--    -     -      -    -      -       0   0   0   0   Infection → Confirmed     
-1.0  1.0   1.0    1.0  1.0    1.0     1   0   1   0   Infection → Suspected     
+F1    Sens  Spec   PPV   NPV    Kappa   TP  FN  TN  FP  Label                   
+0.75  0.75  0.833  0.75  0.833  0.583   3   1   5   1   *                       
+1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Deceased → *            
+1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Deceased → False        
+-     0.0   0.667  0.0   0.667  -0.333  0   1   2   1   Deceased → Datetime → * 
+-     0.0   1.0    -     0.5    0.0     0   1   1   0   Deceased → Datetime →   
+                                                        11/12/25                
+-     -     0.5    0.0   1.0    0.0     0   0   1   1   Deceased → Datetime →   
+                                                        11/13/25                
+1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Fungal → *              
+1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Fungal → Confirmed      
+1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Infection → *           
+-     -     -      -     -      -       0   0   0   0   Infection → Confirmed   
+1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Infection → Suspected   
+
+Ignoring 1 invalid mention
 """,
         )

--- a/tests/test_frequency.py
+++ b/tests/test_frequency.py
@@ -201,16 +201,13 @@ class TestFrequency(base.TestCase):
             """╭───────────┬────────────────────────────────┬───────────────────────┬───────╮
 │ Annotator │ Label                          │ Mention               │ Count │
 ├───────────┼────────────────────────────────┼───────────────────────┼───────┤
-│ All       │ Deceased                       │ death*                │ 1     │
 │ All       │ Deceased → False               │ alive                 │ 3     │
 │ All       │ Deceased → Datetime → 11/12/25 │ alive*                │ 2     │
 │ All       │ Deceased → Datetime → 11/13/25 │ alive*                │ 1     │
 │ All       │ Fungal → Confirmed             │ fungus found in lungs │ 3     │
-│ All       │ Infection                      │ death*                │ 1     │
 │ All       │ Infection → Confirmed          │ maybe got infected*   │ 1     │
 │ All       │ Infection → Suspected          │ maybe got infected*   │ 2     │
 ├───────────┼────────────────────────────────┼───────────────────────┼───────┤
-│ alice     │ Deceased                       │ death*                │ 1     │
 │ alice     │ Deceased → False               │ alive                 │ 1     │
 │ alice     │ Deceased → Datetime → 11/12/25 │ alive*                │ 1     │
 │ alice     │ Fungal → Confirmed             │ fungus found in lungs │ 1     │
@@ -219,7 +216,6 @@ class TestFrequency(base.TestCase):
 │ bob       │ Deceased → False               │ alive                 │ 1     │
 │ bob       │ Deceased → Datetime → 11/13/25 │ alive*                │ 1     │
 │ bob       │ Fungal → Confirmed             │ fungus found in lungs │ 1     │
-│ bob       │ Infection                      │ death*                │ 1     │
 │ bob       │ Infection → Suspected          │ maybe got infected*   │ 1     │
 ├───────────┼────────────────────────────────┼───────────────────────┼───────┤
 │ carla     │ Deceased → False               │ alive                 │ 1     │
@@ -227,6 +223,7 @@ class TestFrequency(base.TestCase):
 │ carla     │ Fungal → Confirmed             │ fungus found in lungs │ 1     │
 │ carla     │ Infection → Confirmed          │ maybe got infected*   │ 1     │
 ╰───────────┴────────────────────────────────┴───────────────────────┴───────╯
+  Ignoring 2 invalid mentions
   * This text has multiple associated labels.
 """,
         )

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -114,41 +114,34 @@ class TestLabels(base.TestCase):
             """╭───────────┬────────────────────────────────┬─────────────╮
 │ Annotator │ Label                          │ Chart Count │
 ├───────────┼────────────────────────────────┼─────────────┤
-│ Any       │ Deceased                       │ 1           │
 │ Any       │ Deceased → False               │ 1           │
 │ Any       │ Deceased → Datetime → 11/12/25 │ 1           │
 │ Any       │ Deceased → Datetime → 11/13/25 │ 1           │
 │ Any       │ Fungal → Confirmed             │ 1           │
-│ Any       │ Infection                      │ 1           │
 │ Any       │ Infection → Confirmed          │ 1           │
 │ Any       │ Infection → Suspected          │ 1           │
 ├───────────┼────────────────────────────────┼─────────────┤
-│ alice     │ Deceased                       │ 1           │
 │ alice     │ Deceased → False               │ 1           │
 │ alice     │ Deceased → Datetime → 11/12/25 │ 1           │
 │ alice     │ Deceased → Datetime → 11/13/25 │ 0           │
 │ alice     │ Fungal → Confirmed             │ 1           │
-│ alice     │ Infection                      │ 0           │
 │ alice     │ Infection → Confirmed          │ 0           │
 │ alice     │ Infection → Suspected          │ 1           │
 ├───────────┼────────────────────────────────┼─────────────┤
-│ bob       │ Deceased                       │ 0           │
 │ bob       │ Deceased → False               │ 1           │
 │ bob       │ Deceased → Datetime → 11/12/25 │ 0           │
 │ bob       │ Deceased → Datetime → 11/13/25 │ 1           │
 │ bob       │ Fungal → Confirmed             │ 1           │
-│ bob       │ Infection                      │ 1           │
 │ bob       │ Infection → Confirmed          │ 0           │
 │ bob       │ Infection → Suspected          │ 1           │
 ├───────────┼────────────────────────────────┼─────────────┤
-│ carla     │ Deceased                       │ 0           │
 │ carla     │ Deceased → False               │ 1           │
 │ carla     │ Deceased → Datetime → 11/12/25 │ 1           │
 │ carla     │ Deceased → Datetime → 11/13/25 │ 0           │
 │ carla     │ Fungal → Confirmed             │ 1           │
-│ carla     │ Infection                      │ 0           │
 │ carla     │ Infection → Confirmed          │ 1           │
 │ carla     │ Infection → Suspected          │ 0           │
 ╰───────────┴────────────────────────────────┴─────────────╯
+  Ignoring 2 invalid mentions
 """,
         )

--- a/tests/test_mcnemar.py
+++ b/tests/test_mcnemar.py
@@ -66,14 +66,14 @@ Truth: alice
 Annotators: bob, carla
 
 McNemar  P-value  BC  OL  OR  BW  Label                         
-N/A      0.688    10  2   3   1   *                             
-N/A      1.0      1   0   0   1   Deceased                      
+N/A      1.0      8   2   2   0   *                             
 N/A      1.0      2   0   0   0   Deceased → False              
 N/A      0.5      1   0   1   0   Deceased → Datetime → 11/12/25
 N/A      0.5      1   0   1   0   Deceased → Datetime → 11/13/25
 N/A      1.0      2   0   0   0   Fungal → Confirmed            
-N/A      0.5      1   0   1   0   Infection                     
 N/A      0.5      1   1   0   0   Infection → Confirmed         
 N/A      0.5      1   1   0   0   Infection → Suspected         
+
+Ignoring 2 invalid mentions
 """,
         )

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -215,14 +215,12 @@ class TestMentions(base.TestCase):
 │ alice     │ 1308     │ alive                 │ Deceased → False              │
 │ alice     │ 1308     │ alive                 │ Deceased → Datetime →         │
 │           │          │                       │ 11/12/25                      │
-│ alice     │ 1308     │ death                 │ Deceased                      │
 │ alice     │ 1308     │ fungus found in lungs │ Fungal → Confirmed            │
 │ alice     │ 1308     │ maybe got infected    │ Infection → Suspected         │
 ├───────────┼──────────┼───────────────────────┼───────────────────────────────┤
 │ bob       │ 1308     │ alive                 │ Deceased → False              │
 │ bob       │ 1308     │ alive                 │ Deceased → Datetime →         │
 │           │          │                       │ 11/13/25                      │
-│ bob       │ 1308     │ death                 │ Infection                     │
 │ bob       │ 1308     │ fungus found in lungs │ Fungal → Confirmed            │
 │ bob       │ 1308     │ maybe got infected    │ Infection → Suspected         │
 ├───────────┼──────────┼───────────────────────┼───────────────────────────────┤
@@ -232,5 +230,6 @@ class TestMentions(base.TestCase):
 │ carla     │ 1308     │ fungus found in lungs │ Fungal → Confirmed            │
 │ carla     │ 1308     │ maybe got infected    │ Infection → Confirmed         │
 ╰───────────┴──────────┴───────────────────────┴───────────────────────────────╯
+  Ignoring 2 invalid mentions
 """,
         )

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -35,46 +35,6 @@ class TestStudio(base.TestCase):
             with self.assertRaisesRegex(ValueError, "Unrecognized Label Studio result type"):
                 studio.ExportFile(tmpfile.name)
 
-    def test_invalid_label_id(self):
-        with tempfile.NamedTemporaryFile("wt") as tmpfile:
-            json.dump(
-                [
-                    {
-                        "id": 1,
-                        "annotations": [
-                            {
-                                "completed_by": 1,
-                                "result": [
-                                    {
-                                        "id": "id1",
-                                        "value": {"labels": ["A"]},
-                                        "type": "labels",
-                                        "from_name": "label",
-                                    },
-                                    {
-                                        "id": "id1",
-                                        "value": {"choices": ["A1.1"]},
-                                        "type": "choices",
-                                        "from_name": "A",
-                                    },
-                                    {
-                                        "id": "bogus-id",
-                                        "value": {"choices": ["A1.2"]},
-                                        "type": "choices",
-                                        "from_name": "A",
-                                    },
-                                ],
-                            },
-                        ],
-                        "data": {"text": "", "label": []},
-                    },
-                ],
-                tmpfile,
-            )
-            tmpfile.flush()
-            with self.assertRaisesRegex(ValueError, "Unrecognized sublabel ID 'bogus-id'."):
-                studio.ExportFile(tmpfile.name)
-
     def test_merging(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(f"{tmpdir}/one.json", "w", encoding="utf8") as f:


### PR DESCRIPTION
Likely a reviewer mistake, this indicates incomplete data.

Unfortunately, we can only infer which labels should have sublabels by inspecting the export, since we don't have the Label Studio config handy by the point we get the file.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
