### PR TITLE
accuracy: change how aggregate sublabel math is calculated

### DIFF
--- a/chart_review/agree.py
+++ b/chart_review/agree.py
@@ -44,23 +44,32 @@ def confusion_matrix(
     FN = list()  # False Negative
     TN = list()  # True Negative
 
+    # Group sublabels together, so we can compare them as a group.
+    # Same sublabel value = TP, different sublabel value = FP, present or not = TN/FN
+    sublabel_groups = {}
+    for label in label_set:
+        sublabel_key = (label.label, label.sublabel_name)
+        group_set = sublabel_groups.setdefault(sublabel_key, set())
+        group_set.add(label)
+
     for note_id in note_range:
         truth_note_mentions = truth_mentions.get(note_id, set())
         annotator_note_mentions = annotator_mentions.get(note_id, set())
 
-        for label in sorted(label_set):
-            key = {note_id: label}
-            truth_positive = label in truth_note_mentions
-            annotator_positive = label in annotator_note_mentions
+        for sublabel_key in sorted(sublabel_groups):
+            all_sublabel_values = sublabel_groups[sublabel_key]
+            truth_values = all_sublabel_values & truth_note_mentions
+            annotator_values = all_sublabel_values & annotator_note_mentions
 
-            if truth_positive and annotator_positive:
-                TP.append(key)
-            elif truth_positive and not annotator_positive:
-                FN.append(key)
-            elif not truth_positive and annotator_positive:
-                FP.append(key)
-            elif not truth_positive and not annotator_positive:
+            key = (note_id, *sublabel_key)
+            if not truth_values and not annotator_values:
                 TN.append(key)
+            elif truth_values and not annotator_values:
+                FN.append(key)
+            elif truth_values != annotator_values:
+                FP.append(key)
+            elif truth_values == annotator_values:
+                TP.append(key)
             else:
                 raise Exception("Guard: Impossible comparison of reviewers")  # pragma: no cover
 

--- a/chart_review/commands/accuracy.py
+++ b/chart_review/commands/accuracy.py
@@ -67,7 +67,8 @@ def print_accuracy(args: argparse.Namespace) -> None:
             table.add_section()
             for label in labels:
                 for classification in ["TN", "TP", "FN", "FP"]:
-                    if {note_id: label} in matrices[label][classification]:
+                    label_key = (note_id, label.label, label.sublabel_name)
+                    if label_key in matrices[label][classification]:
                         style = "bold" if classification[0] == "F" else None  # highlight errors
                         class_text = rich.text.Text(classification, style=style)
                         table.add_row(str(note_id), str(label), class_text)

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -115,20 +115,20 @@ Truth: alice
 Annotator: bob
 Macro F1: 1.0
 
-F1    Sens  Spec   PPV   NPV    Kappa   TP  FN  TN  FP  Label                   
-0.75  0.75  0.833  0.75  0.833  0.583   3   1   5   1   *                       
-1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Deceased → *            
-1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Deceased → False        
--     0.0   0.667  0.0   0.667  -0.333  0   1   2   1   Deceased → Datetime → * 
--     0.0   1.0    -     0.5    0.0     0   1   1   0   Deceased → Datetime →   
-                                                        11/12/25                
--     -     0.5    0.0   1.0    0.0     0   0   1   1   Deceased → Datetime →   
-                                                        11/13/25                
-1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Fungal → *              
-1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Fungal → Confirmed      
-1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Infection → *           
--     -     -      -     -      -       0   0   0   0   Infection → Confirmed   
-1.0   1.0   1.0    1.0   1.0    1.0     1   0   1   0   Infection → Suspected   
+F1     Sens  Spec  PPV   NPV  Kappa  TP  FN  TN  FP  Label                      
+0.857  1.0   0.8   0.75  1.0  0.75   3   0   4   1   *                          
+1.0    1.0   1.0   1.0   1.0  1.0    1   0   1   0   Deceased → *               
+1.0    1.0   1.0   1.0   1.0  1.0    1   0   1   0   Deceased → False           
+-      -     0.5   0.0   1.0  0.0    0   0   1   1   Deceased → Datetime → *    
+-      0.0   1.0   -     0.5  0.0    0   1   1   0   Deceased → Datetime →      
+                                                     11/12/25                   
+-      -     0.5   0.0   1.0  0.0    0   0   1   1   Deceased → Datetime →      
+                                                     11/13/25                   
+1.0    1.0   1.0   1.0   1.0  1.0    1   0   1   0   Fungal → *                 
+1.0    1.0   1.0   1.0   1.0  1.0    1   0   1   0   Fungal → Confirmed         
+1.0    1.0   1.0   1.0   1.0  1.0    1   0   1   0   Infection → *              
+-      -     -     -     -    -      0   0   0   0   Infection → Confirmed      
+1.0    1.0   1.0   1.0   1.0  1.0    1   0   1   0   Infection → Suspected      
 
 Ignoring 1 invalid mention
 """,

--- a/tests/test_agree.py
+++ b/tests/test_agree.py
@@ -18,10 +18,10 @@ class TestAgreement(base.TestCase):
             "bob",
             None,
             {
-                "FN": [{1: base.Label("Cough")}],
-                "FP": [{1: base.Label("Headache")}, {2: base.Label("Cough")}],
-                "TN": [{1: base.Label("Fever")}, {2: base.Label("Headache")}],
-                "TP": [{2: base.Label("Fever")}],
+                "FN": [(1, "Cough", "")],
+                "FP": [(1, "Headache", ""), (2, "Cough", "")],
+                "TN": [(1, "Fever", ""), (2, "Headache", "")],
+                "TP": [(2, "Fever", "")],
             },
         ),
         (
@@ -29,10 +29,10 @@ class TestAgreement(base.TestCase):
             "alice",
             {},
             {
-                "FN": [{1: base.Label("Headache")}, {2: base.Label("Cough")}],
-                "FP": [{1: base.Label("Cough")}],
-                "TN": [{1: base.Label("Fever")}, {2: base.Label("Headache")}],
-                "TP": [{2: base.Label("Fever")}],
+                "FN": [(1, "Headache", ""), (2, "Cough", "")],
+                "FP": [(1, "Cough", "")],
+                "TN": [(1, "Fever", ""), (2, "Headache", "")],
+                "TP": [(2, "Fever", "")],
             },
         ),
         (
@@ -40,8 +40,8 @@ class TestAgreement(base.TestCase):
             "bob",
             base.labels(["Cough"]),
             {
-                "FN": [{1: base.Label("Cough")}],
-                "FP": [{2: base.Label("Cough")}],
+                "FN": [(1, "Cough", "")],
+                "FP": [(2, "Cough", "")],
                 "TN": [],
                 "TP": [],
             },
@@ -61,6 +61,43 @@ class TestAgreement(base.TestCase):
 
         matrix = agree.confusion_matrix(annotations, truth, annotator, notes, labels=labels)
         self.assertEqual(expected_matrix, matrix)
+
+    def test_confusion_matrix_for_sublabels(self):
+        annotations = defines.ProjectAnnotations(
+            labels=base.labels({"Top|Sub|A", "Top|Sub|B", "Top|Sub|C"}),
+            mentions={
+                "alice": {
+                    1: base.labels({"Top|Sub|A"}),  # TP
+                    2: base.labels({"Top|Sub|A"}),  # FP
+                    3: base.labels({"Top|Sub|A", "Top|Sub|B"}),  # TP
+                    4: base.labels({"Top|Sub|A", "Top|Sub|B"}),  # FP
+                    5: set(),  # TN
+                    6: base.labels({"Top|Sub|A"}),  # FN
+                    7: set(),  # FP
+                },
+                "bob": {
+                    1: base.labels({"Top|Sub|A"}),  # TP
+                    2: base.labels({"Top|Sub|C"}),  # FP
+                    3: base.labels({"Top|Sub|A", "Top|Sub|B"}),  # TP
+                    4: base.labels({"Top|Sub|C", "Top|Sub|B"}),  # FP
+                    5: set(),  # TN
+                    6: set(),  # FN
+                    7: base.labels({"Top|Sub|A"}),  # FP
+                },
+            },
+        )
+        notes = [1, 2, 3, 4, 5, 6, 7]
+
+        matrix = agree.confusion_matrix(annotations, "alice", "bob", notes)
+        self.assertEqual(
+            matrix,
+            {
+                "FN": [(6, "Top", "Sub")],
+                "FP": [(2, "Top", "Sub"), (4, "Top", "Sub"), (7, "Top", "Sub")],
+                "TN": [(5, "Top", "Sub")],
+                "TP": [(1, "Top", "Sub"), (3, "Top", "Sub")],
+            },
+        )
 
     @ddt.data(
         # Examples pulled from https://en.wikipedia.org/wiki/Cohen's_kappa#Examples


### PR DESCRIPTION
Rather than just counting all matrix values for each sublabel value underneath an entire sublabel tree, do some more clever comparisions, treating sublabel values as mutually exclusive, so we can say that two different values means a single FP, rather than both a FN and a FP for each value individually.

The individual sublabel value rows are still there, this math change only affects the aggregate/roll-up rows.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
