### PR TITLE
Add new `disagreements` subcommand

### DIFF
--- a/chart_review/cli.py
+++ b/chart_review/cli.py
@@ -3,7 +3,16 @@
 import argparse
 import sys
 
-from chart_review.commands import accuracy, default, frequency, ids, labels, mcnemar, mentions
+from chart_review.commands import (
+    accuracy,
+    default,
+    disagreements,
+    frequency,
+    ids,
+    labels,
+    mcnemar,
+    mentions,
+)
 
 
 def define_parser() -> argparse.ArgumentParser:
@@ -13,6 +22,9 @@ def define_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers()
     accuracy.make_subparser(subparsers.add_parser("accuracy", help="calculate F1 and Kappa scores"))
+    disagreements.make_subparser(
+        subparsers.add_parser("disagreements", help="show label disagreements")
+    )
     frequency.make_subparser(
         subparsers.add_parser("frequency", help="show counts of each text mention")
     )

--- a/chart_review/commands/disagreements.py
+++ b/chart_review/commands/disagreements.py
@@ -1,0 +1,104 @@
+"""Command for disagreement review."""
+
+import argparse
+
+import rich
+import rich.box
+import rich.table
+import rich.text
+
+from chart_review import cli_utils, console_utils
+
+
+def make_subparser(parser: argparse.ArgumentParser) -> None:
+    cli_utils.add_project_args(parser)
+    cli_utils.add_output_args(parser)
+    parser.add_argument("--with-ids", action="store_true", help="show each chart’s full IDs")
+    parser.add_argument("truth_annotator")
+    parser.add_argument("annotator")
+    parser.set_defaults(func=print_disagreements)
+
+
+def print_disagreements(args: argparse.Namespace) -> None:
+    """Shows disagreement of labels between two annotators."""
+    reader = cli_utils.get_cohort_reader(args)
+    truth = args.truth_annotator
+    annotator = args.annotator
+
+    if truth not in reader.note_range:
+        raise ValueError(f"Unrecognized annotator '{truth}'")
+    if annotator not in reader.note_range:
+        raise ValueError(f"Unrecognized annotator '{annotator}'")
+
+    if truth == annotator:
+        raise ValueError("Can’t compare the same annotator with themselves.")
+
+    # Grab the intersection of ranges
+    note_range = set(reader.note_range[truth])
+    note_range &= set(reader.note_range[annotator])
+
+    labels = sorted(reader.class_labels)
+
+    # Calculate confusion matrices
+    matrices = {
+        label: reader.confusion_matrix(truth, annotator, note_range, label) for label in labels
+    }
+
+    console = rich.get_console()
+
+    if args.with_ids:
+        table = cli_utils.create_table("Chart ID", "FHIR ID", "Anon ID", "Label", "Classification")
+    else:
+        table = cli_utils.create_table("Chart ID", "Label", "Classification")
+
+    for note in sorted(reader.ls_export.notes, key=lambda x: x.note_id):
+        if note.note_id not in note_range:
+            continue
+
+        ids = []
+
+        # Grab encounters first
+        orig_id = note.encounter_id and f"Encounter/{note.encounter_id}"
+        anon_id = note.anon_encounter_id and f"Encounter/{note.anon_encounter_id}"
+        if orig_id or anon_id:
+            ids.append((orig_id, anon_id))
+
+        # Now each DocRef ID
+        for orig_id, anon_id in note.docref_mappings.items():
+            ids.append((orig_id, anon_id))
+
+        if not ids:
+            ids.append(("", ""))
+
+        table.add_section()
+        for label in labels:
+            for classification in ["FN", "FP"]:
+                label_key = (note.note_id, label.label, label.sublabel_name)
+                if label_key in matrices[label][classification]:
+                    class_text = rich.text.Text(classification)
+                    if args.with_ids:
+                        for id_pair in ids:
+                            table.add_row(
+                                str(note.note_id), id_pair[0], id_pair[1], str(label), class_text
+                            )
+                    else:
+                        table.add_row(str(note.note_id), str(label), class_text)
+                    break
+
+    if args.csv:
+        cli_utils.print_table_as_csv(table)
+        return
+
+    # OK we aren't printing a CSV file to stdout, so we can include a bit more explanation
+    # as a little header to the real results.
+    note_count = len(note_range)
+    chart_word = "chart" if note_count == 1 else "charts"
+    pretty_ranges = f" ({console_utils.pretty_note_range(note_range)})" if note_count > 0 else ""
+    console.print(f"Comparing {note_count} {chart_word}{pretty_ranges}")
+    console.print(f"Truth: {truth}")
+    console.print(f"Annotator: {annotator}")
+
+    console.print()
+    console.print(table)
+
+    console_utils.print_ignored_labels(reader, annotators={truth, annotator})

--- a/chart_review/commands/ids.py
+++ b/chart_review/commands/ids.py
@@ -36,7 +36,7 @@ def print_ids(args: argparse.Namespace) -> None:
 
         # Now each DocRef ID
         for orig_id, anon_id in note.docref_mappings.items():
-            table.add_row(chart_id, f"DocumentReference/{orig_id}", f"DocumentReference/{anon_id}")
+            table.add_row(chart_id, orig_id, anon_id)
             printed = True
 
         if not printed:

--- a/chart_review/studio.py
+++ b/chart_review/studio.py
@@ -169,11 +169,21 @@ class Note:
     anon_encounter_id: str | None = None
 
     @staticmethod
+    def _prefix_note(note_ref: str) -> str:
+        # For historical reasons, prefix DocRef/ if we're dealing with an ID not a Ref
+        return note_ref if "/" in note_ref else f"DocumentReference/{note_ref}"
+
+    @staticmethod
     def parse(entry: dict) -> "Note":
         metadata = entry.get("data", {})
         docref_mappings = metadata.get("docref_mappings", {})
         encounter_id = metadata.get("encounter_id") or metadata.get("enc_id")  # old name
         anon_encounter_id = metadata.get("anon_encounter_id") or metadata.get("anon_id")  # old name
+
+        # Normalize mappings
+        docref_mappings = {
+            Note._prefix_note(key): Note._prefix_note(val) for key, val in docref_mappings.items()
+        }
 
         data_keys = set(metadata.keys())
         annotations = [

--- a/docs/disagreements.md
+++ b/docs/disagreements.md
@@ -1,0 +1,86 @@
+---
+title: Disagreements Command
+parent: Chart Review
+nav_order: 6
+# audience: lightly technical folks
+# type: how-to
+---
+
+# The Disagreements Command
+
+The `disagreements` command will print disagreements for every label in your project,
+between two annotators.
+
+Provide two annotator names (the first name will be considered the ground truth) and
+the disagreements will be printed to the console.
+
+## Example
+
+```shell
+$ chart-review disagreements jill jane
+Comparing 3 charts (1, 3–4)
+Truth: jill
+Annotator: jane
+
+╭──────────┬──────────┬────────────────╮
+│ Chart ID │ Label    │ Classification │
+├──────────┼──────────┼────────────────┤
+│ 1        │ Headache │ FP             │
+├──────────┼──────────┼────────────────┤
+│ 4        │ Cough    │ FN             │
+│ 4        │ Headache │ FP             │
+╰──────────┴──────────┴────────────────╯
+```
+
+## Options
+
+### \-\-with-ids
+
+Use this to also print the FHIR and anonymous IDs for all resources represented by a chart.
+This is the same information from the `ids` command, but presented in one chart for convenience.
+
+#### Example
+
+```shell
+$ chart-review accuracy jill jane --with-ids
+Comparing 3 charts (1, 3–4)
+Truth: jill
+Annotator: jane
+
+╭──────────┬─────────────────────┬─────────────────────┬──────────┬────────────────╮
+│ Chart ID │ FHIR ID             │ Anon ID             │ Label    │ Classification │
+├──────────┼─────────────────────┼─────────────────────┼──────────┼────────────────┤
+│ 1        │ Encounter/A         │ Encounter/X         │ Headache │ FP             │
+│ 1        │ DocumentReference/A │ DocumentReference/X │ Headache │ FP             │
+├──────────┼─────────────────────┼─────────────────────┼──────────┼────────────────┤
+│ 4        │ Encounter/B         │ Encounter/Y         │ Cough    │ FN             │
+│ 4        │ DocumentReference/B │ DocumentReference/Y │ Cough    │ FN             │
+│ 4        │ Encounter/B         │ Encounter/Y         │ Headache │ FP             │
+│ 4        │ DocumentReference/B │ DocumentReference/Y │ Headache │ FP             │
+╰──────────┴─────────────────────┴─────────────────────┴──────────┴────────────────╯
+```
+
+### \-\-csv
+
+Print the disagreement chart in a machine-parseable CSV format.
+
+#### Examples
+
+```shell
+$ chart-review disagreements jill jane --csv
+chart_id,label,classification
+1,Headache,FP
+4,Cough,FN
+4,Headache,FP
+```
+
+```shell
+$ chart-review disagreements jill jane --with-ids --csv
+chart_id,fhir_id,anon_id,label,classification
+1,Encounter/A,Encounter/X,Headache,FP
+1,DocumentReference/A,DocumentReference/X,Headache,FP
+4,Encounter/B,Encounter/Y,Cough,FN
+4,DocumentReference/B,DocumentReference/Y,Cough,FN
+4,Encounter/B,Encounter/Y,Headache,FP
+4,DocumentReference/B,DocumentReference/Y,Headache,FP
+```

--- a/docs/frequency.md
+++ b/docs/frequency.md
@@ -1,7 +1,7 @@
 ---
 title: Frequency Command
 parent: Chart Review
-nav_order: 6
+nav_order: 7
 # audience: lightly technical folks
 # type: how-to
 ---

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -1,7 +1,7 @@
 ---
 title: IDs Command
 parent: Chart Review
-nav_order: 7
+nav_order: 8
 # audience: lightly technical folks
 # type: how-to
 ---

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,7 +1,7 @@
 ---
 title: Labels Command
 parent: Chart Review
-nav_order: 8
+nav_order: 9
 # audience: lightly technical folks
 # type: how-to
 ---

--- a/docs/mcnemar.md
+++ b/docs/mcnemar.md
@@ -1,7 +1,7 @@
 ---
 title: McNemar Command
 parent: Chart Review
-nav_order: 9
+nav_order: 10
 # audience: lightly technical folks
 # type: how-to
 ---

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -1,7 +1,7 @@
 ---
 title: Mentions Command
 parent: Chart Review
-nav_order: 10
+nav_order: 11
 # audience: lightly technical folks
 # type: how-to
 ---

--- a/tests/test_disagreements.py
+++ b/tests/test_disagreements.py
@@ -1,0 +1,217 @@
+"""Tests for commands/disagreements.py"""
+
+import tempfile
+
+from chart_review import common
+from tests import base
+
+
+class TestDisagreements(base.TestCase):
+    @staticmethod
+    def make_simple_export(tmpdir: str) -> None:
+        common.write_json(
+            f"{tmpdir}/export.json",
+            [
+                {
+                    "id": 1,
+                    "annotations": [
+                        {
+                            "completed_by": 1,
+                            "result": [
+                                {
+                                    "value": {
+                                        "labels": [
+                                            "frog",
+                                            "chicken",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            "completed_by": 2,
+                            "result": [
+                                {
+                                    "value": {
+                                        "labels": [
+                                            "frog",
+                                            "horse",
+                                            "ant",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                    "data": {
+                        "encounter_id": "enc",
+                        "anon_encounter_id": "anon-enc",
+                        "docref_mappings": {
+                            "DiagnosticReport/dx": "DiagnosticReport/anon-dx",
+                            "DocumentReference/doc": "anon-doc",
+                        },
+                    },
+                },
+                {  # another chart, without mappings (just to test output in that case)
+                    "id": 2,
+                    "annotations": [
+                        {
+                            "completed_by": 1,
+                            "result": [
+                                {
+                                    "value": {
+                                        "labels": [
+                                            "ant",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            "completed_by": 2,
+                            "result": [{"value": {"labels": []}}],
+                        },
+                    ],
+                },
+                {  # another chart, annotated by a third annotator, should be ignored
+                    "id": 3,
+                    "annotations": [
+                        {
+                            "completed_by": 42,
+                            "result": [
+                                {
+                                    "value": {
+                                        "labels": [
+                                            "elephant",
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        )
+
+    def test_disagreements(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.make_simple_export(tmpdir)
+            stdout = self.run_cli("disagreements", "1", "2", path=tmpdir)
+
+        self.assertEqual(
+            [
+                "Comparing 2 charts (1–2)",
+                "Truth: 1",
+                "Annotator: 2",
+                "",
+                "╭──────────┬─────────┬────────────────╮",
+                "│ Chart ID │ Label   │ Classification │",
+                "├──────────┼─────────┼────────────────┤",
+                "│ 1        │ ant     │ FP             │",
+                "│ 1        │ chicken │ FN             │",
+                "│ 1        │ horse   │ FP             │",
+                "├──────────┼─────────┼────────────────┤",
+                "│ 2        │ ant     │ FN             │",
+                "╰──────────┴─────────┴────────────────╯",
+            ],
+            stdout.splitlines(),
+        )
+
+    def test_csv(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.make_simple_export(tmpdir)
+            stdout = self.run_cli("disagreements", "--csv", "1", "2", path=tmpdir)
+
+        self.assertEqual(
+            [
+                "chart_id,label,classification",
+                "1,ant,FP",
+                "1,chicken,FN",
+                "1,horse,FP",
+                "2,ant,FN",
+            ],
+            stdout.splitlines(),
+        )
+
+    def test_with_ids(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.make_simple_export(tmpdir)
+            stdout = self.run_cli("disagreements", "--with-ids", "1", "2", path=tmpdir)
+
+        self.assertEqual(
+            [
+                "Comparing 2 charts (1–2)",
+                "Truth: 1",
+                "Annotator: 2",
+                "",
+                "╭──────────┬───────────────────┬────────────────────┬─────────┬────────────────╮",
+                "│ Chart ID │ FHIR ID           │ Anon ID            │ Label   │ Classification │",
+                "├──────────┼───────────────────┼────────────────────┼─────────┼────────────────┤",
+                "│ 1        │ Encounter/enc     │ Encounter/anon-enc │ ant     │ FP             │",
+                "│ 1        │ DiagnosticReport/ │ DiagnosticReport/a │ ant     │ FP             │",
+                "│          │ dx                │ non-dx             │         │                │",
+                "│ 1        │ DocumentReference │ DocumentReference/ │ ant     │ FP             │",
+                "│          │ /doc              │ anon-doc           │         │                │",
+                "│ 1        │ Encounter/enc     │ Encounter/anon-enc │ chicken │ FN             │",
+                "│ 1        │ DiagnosticReport/ │ DiagnosticReport/a │ chicken │ FN             │",
+                "│          │ dx                │ non-dx             │         │                │",
+                "│ 1        │ DocumentReference │ DocumentReference/ │ chicken │ FN             │",
+                "│          │ /doc              │ anon-doc           │         │                │",
+                "│ 1        │ Encounter/enc     │ Encounter/anon-enc │ horse   │ FP             │",
+                "│ 1        │ DiagnosticReport/ │ DiagnosticReport/a │ horse   │ FP             │",
+                "│          │ dx                │ non-dx             │         │                │",
+                "│ 1        │ DocumentReference │ DocumentReference/ │ horse   │ FP             │",
+                "│          │ /doc              │ anon-doc           │         │                │",
+                "├──────────┼───────────────────┼────────────────────┼─────────┼────────────────┤",
+                "│ 2        │                   │                    │ ant     │ FN             │",
+                "╰──────────┴───────────────────┴────────────────────┴─────────┴────────────────╯",
+            ],
+            stdout.splitlines(),
+        )
+
+    def test_with_ids_cvs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.make_simple_export(tmpdir)
+            stdout = self.run_cli("disagreements", "--with-ids", "--csv", "1", "2", path=tmpdir)
+
+        self.assertEqual(
+            [
+                "chart_id,fhir_id,anon_id,label,classification",
+                "1,Encounter/enc,Encounter/anon-enc,ant,FP",
+                "1,DiagnosticReport/dx,DiagnosticReport/anon-dx,ant,FP",
+                "1,DocumentReference/doc,DocumentReference/anon-doc,ant,FP",
+                "1,Encounter/enc,Encounter/anon-enc,chicken,FN",
+                "1,DiagnosticReport/dx,DiagnosticReport/anon-dx,chicken,FN",
+                "1,DocumentReference/doc,DocumentReference/anon-doc,chicken,FN",
+                "1,Encounter/enc,Encounter/anon-enc,horse,FP",
+                "1,DiagnosticReport/dx,DiagnosticReport/anon-dx,horse,FP",
+                "1,DocumentReference/doc,DocumentReference/anon-doc,horse,FP",
+                "2,,,ant,FN",
+            ],
+            stdout.splitlines(),
+        )
+
+    def test_bad_annotator(self):
+        # Truth
+        with self.capture_stderr() as stderr:
+            with self.assertRaises(SystemExit):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    self.make_simple_export(tmpdir)
+                    self.run_cli("disagreements", "nope1", "2", path=tmpdir)
+        self.assertEqual("Unrecognized annotator 'nope1'\n", stderr.getvalue())
+
+        # Annotator
+        with self.capture_stderr() as stderr:
+            with self.assertRaises(SystemExit):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    self.make_simple_export(tmpdir)
+                    self.run_cli("disagreements", "1", "nope2", path=tmpdir)
+        self.assertEqual("Unrecognized annotator 'nope2'\n", stderr.getvalue())
+
+    def test_same_annotators(self):
+        with self.capture_stderr() as stderr:
+            with self.assertRaises(SystemExit):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    self.make_simple_export(tmpdir)
+                    self.run_cli("disagreements", "1", "1", path=tmpdir)
+        self.assertEqual("Can’t compare the same annotator with themselves.\n", stderr.getvalue())


### PR DESCRIPTION
This shows just label disagreemnts (like `accuracy --verbose` but only the FN/FP rows). Additionally, it offers a `--with-ids` flag to get the note refs too, so you can more easily find the source of disagreements and reconcile them.

Fixes https://github.com/smart-on-fhir/chart-review/issues/85

```
$ chart-review -p site/kidney/ disagreements 1 2
Comparing 1 chart (1308)
Truth: 1
Annotator: 2

╭──────────┬─────────────────────────────────┬────────────────╮
│ Chart ID │ Label                           │ Classification │
├──────────┼─────────────────────────────────┼────────────────┤
│ 1308     │ Deceased → Datetime → free form │ FN             │
│ 1308     │ Deceased → Datetime → Nov 12    │ FP             │
╰──────────┴─────────────────────────────────┴────────────────╯
  Ignoring 2 invalid mentions
```

or

```
$ chart-review -p site/kidney/ disagreements 1 2 --with-ids --csv
chart_id,fhir_id,anon_id,label,classification
1308,Encounter/309deca4-a16f-b02d-b81a-3ef9657b3f8a,Encounter/f9f5499be548d158d7e4691b242fe52fda07851782fcc7852545a97deeb33f0a,Deceased → Datetime → free form,FN
1308,DocumentReference/6a70cb2c-19f7-9e75-3106-4cb4c9823000,DocumentReference/9dfde1599ac87d1cdc59328402f1cf1d030c561a973f00b7a80fa676c024952a,Deceased → Datetime → free form,FN
1308,Encounter/309deca4-a16f-b02d-b81a-3ef9657b3f8a,Encounter/f9f5499be548d158d7e4691b242fe52fda07851782fcc7852545a97deeb33f0a,Deceased → Datetime → Nov 12,FP
1308,DocumentReference/6a70cb2c-19f7-9e75-3106-4cb4c9823000,DocumentReference/9dfde1599ac87d1cdc59328402f1cf1d030c561a973f00b7a80fa676c024952a,Deceased → Datetime → Nov 12,FP
```
### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
